### PR TITLE
[META-47] Remove npm run build from GitHub action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -27,4 +27,3 @@ jobs:
       - run: npm ci
       - run: npm run prettier:all
       - run: npm run lint
-      - run: npm run build


### PR DESCRIPTION
## Description
Remove npm run build from GitHub action because build is already tested by automatic Vercel deployment action

## How I implemented
Updated node.js yaml file in GitHub workflows folder