### PR TITLE
[META-49] Add New GitHub Action to verify Pull Request Format

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,2 @@
+addAssignees: author
+runOnDraft: true

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,0 +1,12 @@
+name: 'PR Auto Assign'
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: '.github/auto-assign.yml'

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -1,0 +1,17 @@
+name: 'PR Checks'
+on:
+  pull_request:
+    types: [opened, edited, ready_for_review, reopened, synchronize]
+permissions: write-all
+jobs:
+  pr-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR Check
+        uses: pczern/verify-pr-action@v0.0.3-alpha.26
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          titleRegex: '[\b(META|BACK|FRONT)-d+]s.+'
+          descriptionRegex: '[\\s\\S]*Description[\\s\\S]{35,}How I implemented[\\s\\S]{45,}'
+          titleMinLength: 20
+          descriptionMinLength: 60

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -11,7 +11,7 @@ jobs:
         uses: pczern/verify-pr-action@v0.0.3-alpha.26
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          titleRegex: '[\b(META|BACK|FRONT)-d+]s.+'
+          titleRegex: '\\[(META|BACK|FRONT)\\-\\d+\\]\\s.+'
           descriptionRegex: '[\\s\\S]*Description[\\s\\S]{35,}How I implemented[\\s\\S]{45,}'
           titleMinLength: 20
           descriptionMinLength: 60

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Check
-        uses: pczern/verify-pr-action@v0.0.3-alpha.27
+        uses: pczern/verify-pr-action@v0.0.3-alpha.29
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           titleRegex: "\\[(META|BACK|FRONT)\\-\\d+\\]\\s.+"

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -11,7 +11,7 @@ jobs:
         uses: pczern/verify-pr-action@v0.0.3-alpha.26
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          titleRegex: \\[(META|BACK|FRONT)\\-\\d+\\]\\s.+
-          descriptionRegex: '[\\s\\S]*Description[\\s\\S]{35,}How I implemented[\\s\\S]{45,}'
+          titleRegex: "\\[(META|BACK|FRONT)\\-\\d+\\]\\s.+"
+          descriptionRegex: "[\\s\\S]*Description[\\s\\S]{35,}How I implemented[\\s\\S]{45,}"
           titleMinLength: 20
           descriptionMinLength: 60

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -11,7 +11,7 @@ jobs:
         uses: pczern/verify-pr-action@v0.0.3-alpha.26
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          titleRegex: '\\[(META|BACK|FRONT)\\-\\d+\\]\\s.+'
+          titleRegex: \\[(META|BACK|FRONT)\\-\\d+\\]\\s.+
           descriptionRegex: '[\\s\\S]*Description[\\s\\S]{35,}How I implemented[\\s\\S]{45,}'
           titleMinLength: 20
           descriptionMinLength: 60

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Check
-        uses: pczern/verify-pr-action@v0.0.3-alpha.26
+        uses: pczern/verify-pr-action@v0.0.3-alpha.27
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           titleRegex: "\\[(META|BACK|FRONT)\\-\\d+\\]\\s.+"


### PR DESCRIPTION
### Description
PR's are all the time malformed according to the Coding Guidelines. This new PR is meant to ensure all open PR's a well formatted.

### How I implemented
I have built a [GitHub action](https://github.com/pczern/verify-pr-action) that will put the PR to draft, if anything is wrong.
This includes:
* `Description` and `How I implemented` is missing and there is not enough text between them
* The title has to have [META-number] or [BACK-number] or [FRONT-number] with text following
* If something goes wrong, labels are added, that will indicate what is wrong and the PR will be put to Draft automatically.

Additionally added another GitHub action https://github.com/kentaro-m/auto-assign-action that will make sure PR's are auto assigned on open to the author