### PR TITLE
[META-55] Update Verify-PR-Action

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: PR Check
-        uses: pczern/verify-pr-action@v0.0.3-alpha.38
+        uses: pczern/verify-pr-action@v0.0.3-alpha.39
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           titleRegex: "\\[(META|BACK|FRONT)\\-\\d+\\]\\s.+"


### PR DESCRIPTION
### Description
The action removed the label `Merge Conflicts` not `Merge Conflict` before.
It could fail when the `description` or `title` field was null.
### How I implemented
* Updated the version to `verify-pr-action@v0.0.3-alpha.39`