### PR TITLE
[FRONT-90] Add profile modal for logout and settings

### DIFF
--- a/src/components/page/overview/TopBar.tsx
+++ b/src/components/page/overview/TopBar.tsx
@@ -149,3 +149,4 @@ const TopBar = ({ columns, nullFunc }: TopBarProps) => (
 )
 
 export default TopBar
+export { TransitionMenuItems }

--- a/src/components/pure/Sidebar/index.tsx
+++ b/src/components/pure/Sidebar/index.tsx
@@ -1,5 +1,11 @@
 import { PropsWithChildren, ReactNode } from 'react'
 import Link from 'next/link'
+
+import { AiFillSmile } from 'react-icons/ai'
+import { Menu } from '@headlessui/react'
+import { TransitionMenuItems } from '@/components/page/overview/TopBar'
+import { FiSettings as Settings, FiLogOut as LogOut } from 'react-icons/fi'
+
 import Box from './Box/Box'
 import SmallSidebar from './Small'
 import Section from './Section'
@@ -8,6 +14,7 @@ type SidebarProps = PropsWithChildren<{
   title: string
   footer: ReactNode
 }>
+
 const Sidebar = ({ footer, ...props }: SidebarProps) => (
   <aside className="flex h-screen w-56 flex-col justify-between border-r border-gray-800">
     <div>
@@ -16,7 +23,39 @@ const Sidebar = ({ footer, ...props }: SidebarProps) => (
           <span className="mr-2 text-18 font-medium">{props.title}</span>
         </Link>
 
-        <div className="h-[30px] w-[30px] rounded-[5px] bg-gray-600" />
+        <Menu as="div" className="relative inline-block text-left">
+          <div>
+            <div className="" />
+
+            <Menu.Button className="flex h-[30px] w-[30px] flex-row items-center rounded-[5px] border border-gray-800 bg-gray-850 px-2 py-1.5 text-14 transition-colors duration-100 hover:bg-gray-700">
+              <AiFillSmile color="#858699" />
+            </Menu.Button>
+          </div>
+
+          <TransitionMenuItems>
+            <Menu.Items className="absolute right-0 z-10 mt-2 w-44 origin-top-right rounded-md bg-gray-700 shadow-lg ring-1 focus:outline-none">
+              <div className="py-1">
+                <Section.Item
+                  id={0}
+                  Icon={Settings}
+                  text="Settings"
+                  path="/settings"
+                  showIcon
+                  editable={false}
+                />
+                <hr className="my-1 h-px border-t-0 bg-transparent bg-gradient-to-r from-transparent via-neutral-500 to-transparent opacity-25 dark:opacity-100" />
+                <Section.Item
+                  id={1}
+                  Icon={LogOut}
+                  text="Logout"
+                  path="/logout"
+                  showIcon
+                  editable={false}
+                />
+              </div>
+            </Menu.Items>
+          </TransitionMenuItems>
+        </Menu>
       </div>
 
       {props.children}

--- a/src/components/pure/Sidebar/index.tsx
+++ b/src/components/pure/Sidebar/index.tsx
@@ -25,15 +25,13 @@ const Sidebar = ({ footer, ...props }: SidebarProps) => (
 
         <Menu as="div" className="relative inline-block text-left">
           <div>
-            <div className="" />
-
             <Menu.Button className="flex h-[30px] w-[30px] flex-row items-center rounded-[5px] border border-gray-800 bg-gray-850 px-2 py-1.5 text-14 transition-colors duration-100 hover:bg-gray-700">
-              <AiFillSmile color="#858699" />
+              <AiFillSmile color="#A5B4FC" />
             </Menu.Button>
           </div>
 
           <TransitionMenuItems>
-            <Menu.Items className="absolute right-0 z-10 mt-2 w-44 origin-top-right rounded-md bg-gray-700 shadow-lg ring-1 focus:outline-none">
+            <Menu.Items className="absolute right-0 z-10 mt-2 origin-top-right rounded-md bg-gray-700 shadow-lg ring-1 focus:outline-none">
               <div className="py-1">
                 <Section.Item
                   id={0}

--- a/src/components/side-effects/NavSidebar.tsx
+++ b/src/components/side-effects/NavSidebar.tsx
@@ -15,7 +15,7 @@ const renderFooter = () => (
       id={0}
       Icon={Settings}
       text="Settings"
-      path="settings"
+      path="/settings"
       showIcon
       editable={false}
     />
@@ -23,7 +23,7 @@ const renderFooter = () => (
       id={1}
       Icon={BookOpen}
       text="Help & Support"
-      path="docs"
+      path="/docs"
       showIcon
       editable={false}
     />


### PR DESCRIPTION
### Description of issue
Somewhere in the Sidebar, eg by clicking on the profile pic, you should get a dropdown with the options to Log Out or Settings, which will then later (not part of this task) lead to the Settings page.

### How I implemented
I used the Menu commponent and added a divider 
Fixed the path of the button of the sidebar

### Other