### PR TITLE
[FRONT-102] Change Hex Values to Tailwind Classes

### DIFF
--- a/src/components/page/details/Chart.tsx
+++ b/src/components/page/details/Chart.tsx
@@ -126,27 +126,27 @@ const Chart = ({ datasets }: ChartProps) => {
                 bottom: 5
               }}
             >
-              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="#2C2D3C" />
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="gray" />
 
               <XAxis
                 dataKey="date"
                 type="number"
                 tick={{ fontSize: '12', fontWeight: 'light' }}
                 tickFormatter={formatDate}
-                stroke="#858699"
+                stroke="gray"
                 allowDataOverflow
                 domain={['dataMin', 'dataMax']}
               />
 
               <YAxis
-                label={{ value: 'Stars', dy: -125, dx: 25, fontSize: '12', fill: '#858699' }}
+                label={{ value: 'Stars', dy: -125, dx: 25, fontSize: '12', fill: 'gray' }}
                 tick={{ fontSize: '12', fontWeight: 'light' }}
-                stroke="#858699"
+                stroke="gray"
                 tickFormatter={formatNumber}
                 domain={[0, 'dataMax']}
               />
 
-              <Tooltip content={<CustomTooltip />} cursor={{ stroke: '#858699', strokeWidth: 1 }} />
+              <Tooltip content={<CustomTooltip />} cursor={{ stroke: 'white', strokeWidth: 1 }} />
 
               <Legend wrapperStyle={{ fontSize: '12px' }} />
 
@@ -160,7 +160,7 @@ const Chart = ({ datasets }: ChartProps) => {
                   dataKey="count"
                   name={dataset.name}
                   type="monotone"
-                  stroke="#8884d8"
+                  stroke="white"
                   dot={false}
                   activeDot={{ r: 4 }}
                 />

--- a/src/components/page/details/Chart.tsx
+++ b/src/components/page/details/Chart.tsx
@@ -157,7 +157,10 @@ const Chart = ({ datasets }: ChartProps) => {
                 domain={[0, 'dataMax']}
               />
 
-              <Tooltip content={<CustomTooltip />} cursor={{ stroke: 'white', strokeWidth: 1 }} />
+              <Tooltip
+                content={<CustomTooltip />}
+                cursor={{ stroke: grayColors['100'], strokeWidth: 1 }}
+              />
 
               <Legend wrapperStyle={{ fontSize: '12px' }} />
 
@@ -171,7 +174,7 @@ const Chart = ({ datasets }: ChartProps) => {
                   dataKey="count"
                   name={dataset.name}
                   type="monotone"
-                  stroke="white"
+                  stroke={grayColors['100']}
                   dot={false}
                   activeDot={{ r: 4 }}
                 />

--- a/src/components/page/details/Chart.tsx
+++ b/src/components/page/details/Chart.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react'
+import resolveConfig from 'tailwindcss/resolveConfig'
 import {
   LineChart,
   Line,
@@ -15,6 +16,16 @@ import Button from '@/components/pure/Button'
 import Modal from '@/components/pure/Modal'
 import formatDate from '@/util/formatDate'
 import formatNumber from '@/util/formatNumber'
+import tailwindConfig from '../../../../tailwind.config'
+
+// The following 3 statements are needed in order to be able to use our Tailwind classes inside JS objects of the recharts library
+const fullConfig = resolveConfig(tailwindConfig)
+
+type ColorObject = {
+  [key: string]: string
+}
+
+const grayColors = fullConfig.theme?.colors?.gray as ColorObject
 
 const TimeframeOptions = [
   { value: 1, label: '1 Month' },
@@ -126,14 +137,14 @@ const Chart = ({ datasets }: ChartProps) => {
                 bottom: 5
               }}
             >
-              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="gray" />
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke={grayColors['800']} />
 
               <XAxis
                 dataKey="date"
                 type="number"
                 tick={{ fontSize: '12', fontWeight: 'light' }}
                 tickFormatter={formatDate}
-                stroke="gray"
+                stroke={grayColors['500']}
                 allowDataOverflow
                 domain={['dataMin', 'dataMax']}
               />
@@ -141,7 +152,7 @@ const Chart = ({ datasets }: ChartProps) => {
               <YAxis
                 label={{ value: 'Stars', dy: -125, dx: 25, fontSize: '12', fill: 'gray' }}
                 tick={{ fontSize: '12', fontWeight: 'light' }}
-                stroke="gray"
+                stroke={grayColors['500']}
                 tickFormatter={formatNumber}
                 domain={[0, 'dataMax']}
               />

--- a/src/components/page/overview/TopBar.tsx
+++ b/src/components/page/overview/TopBar.tsx
@@ -45,7 +45,7 @@ const TopBar = ({ columns, nullFunc }: TopBarProps) => (
       <Menu as="div" className="relative inline-block text-left">
         <div>
           <Menu.Button className="flex flex-row items-center space-x-2 rounded-[5px] border border-gray-800 bg-gray-850 px-2 py-1.5 text-14 transition-colors duration-100 hover:bg-gray-700">
-            <AiOutlineCalendar color="#858699" />
+            <AiOutlineCalendar className="text-gray-500" />
             <p className="leading-none">This week</p>
           </Menu.Button>
         </div>
@@ -96,8 +96,7 @@ const TopBar = ({ columns, nullFunc }: TopBarProps) => (
       <Menu as="div" className="relative inline-block text-left">
         <div>
           <Menu.Button className="flex flex-row items-center space-x-2 rounded-[5px] border border-gray-800 bg-gray-850 px-2 py-1.5 text-14 transition-colors duration-100 hover:bg-gray-700">
-            <TbColumns2 color="#858699" />
-
+            <TbColumns2 className="text-gray-500" />
             <p className="leading-none">Edit Columns</p>
           </Menu.Button>
         </div>


### PR DESCRIPTION
## Description of Issue
[Linear Issue](https://linear.app/la-famiglia-project/issue/FRONT-102/change-hex-colors-to-tailwind-names)
## How I implemented
For the objects from the recharts library, like `CartesianGrid`, `XAxis`, and `YAxis`, we couldn't simply use our Tailwind classes for the `stroke` attribute by default. Thus, we are following [this](https://tailwindcss.com/docs/configuration#referencing-in-java-script:~:text=It%20can%20often%20be%20useful%20to%20reference%20your%20configuration%20values%20in%20your%20own%20client%2Dside%20JavaScript%20%E2%80%94%20for%20example%20to%20access%20some%20of%20your%20theme%20values%20when%20dynamically%20applying%20inline%20styles%20in%20a%20React%20or%20Vue%20component.) approach to be able to use our Tailwind classes. Thanks to Clemens for the suggestion.

I've used `gray-500` for the XAxis and YAxis, `gray-800` for the dotted lines in the background, and `gray-100` for the name and graph line. All good?
![image](https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/61106168/9cc4677a-fede-4204-89bc-c5111c44cb7b)

## Other
A neat trick to find all hex code occurrences in WebStorm:
`Cmd + Shift + F` to open global search, then tick the `RegEx` search, then type in the RegEx for hex values (`#[0-9a-fA-F]{6}`):
![image](https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/61106168/924ae810-8cb6-40d3-89e2-cf3d906724ba)

Additionally, you can filter by file type. In my case only .tsx files were interesting:
![image](https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/61106168/16efb121-fa4c-4884-9079-dc59a911311e)
