### PR TITLE
[META-76] Fix lint-staged to run only on staged files

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint ./src --cache --fix",
-      "prettier --write"
+      "prettier --write",
+      "eslint"
     ],
     "*.{html,css,scss,sass,md,mdx}": "prettier --write"
   }


### PR DESCRIPTION
### Description
Eslint should now run only on staged files

### How I implemented
* Removed caching, and fixing from Lint-staged configuration in `package.json`, will prevent race conditions and any issues with cache we might have