### PR TITLE
[META-59] Integrate backend data (logo, owner, eli5)

### DIFF
--- a/codegen.config.ts
+++ b/codegen.config.ts
@@ -1,12 +1,19 @@
 import type { CodegenConfig } from '@graphql-codegen/cli'
-import BASE_URL from './src/constants/baseUrl'
 
 const config: CodegenConfig = {
-  // @TODO environment variable doesn't work, fix
-  schema: BASE_URL,
-  documents: './src/queries/**/*.graphql',
+  schema: [
+    {
+      // @TODO figure out how to use env variables here
+      'http://157.245.24.200/graphql': {
+        headers: {
+          Authorization: '<your-auth-token>' // log document.cookie in console and copy/ paste the result
+        }
+      }
+    }
+  ],
+  documents: './src/graphql/queries/**/*.graphql',
   generates: {
-    './src/generated/gql.ts': {
+    './src/graphql/generated/gql.ts': {
       plugins: ['typescript', 'typescript-operations', 'typescript-urql']
     }
   },

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  reactStrictMode: true
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com'
+      }
+    ]
+  }
 }
 
 module.exports = nextConfig

--- a/src/components/page/details/ProjectInformation.tsx
+++ b/src/components/page/details/ProjectInformation.tsx
@@ -1,8 +1,9 @@
+import Image from 'next/image'
 import { FiBookmark as Bookmark } from 'react-icons/fi'
 import Button from '@/components/pure/Button'
 
 type ProjectInformationProps = {
-  image?: string
+  image: string
   name: string
   url: string
   eli5: string
@@ -17,15 +18,16 @@ const ProjectInformation = ({ image, url, name, eli5, tags }: ProjectInformation
   <div className="border-b border-gray-800 px-7 py-6">
     <div className="mb-6 flex flex-row items-center justify-between">
       <div className="flex flex-row items-center">
-        {/* @TODO Replace with actual image */}
-        <div className="mr-4 h-[30px] w-[30px] rounded-[5px] bg-gray-600" />
+        <div className="relative mr-4 h-8 w-8 overflow-hidden rounded-[5px] bg-gray-600">
+          <Image src={image} alt="logo" fill sizes="32px" />
+        </div>
 
-        <h1 className="mr-3 text-20 font-medium">
-          <a href={url} target="_blank" rel="noreferrer">
+        <a href={url} target="_blank" rel="noreferrer">
+          <h1 className="mr-3 text-20 font-medium">
             {name.slice(0, 32)}
             {name.length > 32 ? '...' : ''}
-          </a>
-        </h1>
+          </h1>
+        </a>
 
         {tags.length > 0 ? (
           tags.map((text) => (
@@ -56,9 +58,5 @@ const ProjectInformation = ({ image, url, name, eli5, tags }: ProjectInformation
     <p className="text-14 font-light">{eli5}</p>
   </div>
 )
-
-ProjectInformation.defaultProps = {
-  image: null
-}
 
 export default ProjectInformation

--- a/src/components/pure/ProjectsTable/columns.tsx
+++ b/src/components/pure/ProjectsTable/columns.tsx
@@ -6,23 +6,29 @@ import { VscIssues } from 'react-icons/vsc'
 import GitHubStatisticItem from '@/components/pure/Sidebar/Box/GithubStatItem'
 import { Project } from '@/graphql/generated/gql'
 import formatNumber from '@/util/formatNumber'
-import Logo from '@/assets/logo.svg'
 
 const columnHelper = createColumnHelper<Project>()
 
-// @TODO Format large numbers
 // @TODO Make columns sortable, filterable, dynamic
 const columns = [
-  columnHelper.accessor(() => '', {
-    header: 'Logo',
-    // @TODO Add real logo
-    // @TODO Fix next image types
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    cell: () => <Image src={Logo} alt="logo" className="ml-2 h-5 w-5" />
-  }),
+  columnHelper.accessor(
+    ({ organization, associatedPerson }) => organization?.avatarUrl || associatedPerson?.avatarUrl,
+    {
+      header: 'Logo',
+      cell: (info) => (
+        <div className="relative ml-2 h-6 w-6 overflow-hidden rounded-[5px]">
+          <Image src={info.getValue() as string} alt="logo" fill sizes="24px" />
+        </div>
+      )
+    }
+  ),
   // @TODO Adjust for user owners
   columnHelper.accessor(
-    ({ organization, name }) => `${organization?.login || 'user'} / ${name as string}`.slice(0, 32),
+    ({ organization, associatedPerson, name }) =>
+      `${(organization?.login || associatedPerson?.login) as string} / ${name as string}`.slice(
+        0,
+        32
+      ),
     {
       id: 'nameWithOwner',
       header: 'Name',

--- a/src/components/side-effects/Details/index.tsx
+++ b/src/components/side-effects/Details/index.tsx
@@ -105,10 +105,12 @@ const Details = ({ id }: DetailsProps) => {
       <div className="flex grow">
         <div className="w-4/5 flex-row border-t border-solid border-gray-800">
           <ProjectInformation
-            // @TODO Add actual image URL
-            image={project?.organization?.avatarUrl as string}
-            // @TODO Adjust for owner (could be user or organization)
-            name={`${project.organization?.login || 'user'} / ${project.name as string}`}
+            image={
+              (project.organization?.avatarUrl || project.associatedPerson?.avatarUrl) as string
+            }
+            name={`${
+              (project.organization?.login || project.associatedPerson?.login) as string
+            } / ${project.name as string}`}
             url={project.githubUrl as string}
             eli5={project.eli5 || project.about || 'No description'}
             // @TODO Replace with actual tags

--- a/src/graphql/generated/gql.ts
+++ b/src/graphql/generated/gql.ts
@@ -695,10 +695,9 @@ export type ProjectDetailsQuery = {
       node: {
         __typename?: 'Project'
         id: any
-        nodeId: string
-        eli5?: string | null
-        about?: string | null
         name?: string | null
+        about?: string | null
+        eli5?: string | null
         starCount?: number | null
         issueCount?: number | null
         forkCount?: number | null
@@ -707,10 +706,21 @@ export type ProjectDetailsQuery = {
         githubUrl?: string | null
         websiteUrl?: string | null
         starHistory?: Array<any | null> | null
+        owningPerson?: any | null
+        owningOrganization?: any | null
+        associatedPerson?: {
+          __typename?: 'AssociatedPerson'
+          id: any
+          name?: string | null
+          login?: string | null
+          avatarUrl?: string | null
+          email?: string | null
+          githubUrl?: string | null
+          twitterUsername?: string | null
+        } | null
         organization?: {
           __typename?: 'Organization'
           id: any
-          nodeId: string
           login?: string | null
           avatarUrl?: string | null
         } | null
@@ -730,19 +740,29 @@ export type TrendingProjectsQuery = {
       node: {
         __typename?: 'Project'
         id: any
-        nodeId: string
         name?: string | null
         starCount?: number | null
         issueCount?: number | null
         forkCount?: number | null
         pullRequestCount?: number | null
         contributorCount?: number | null
+        githubUrl?: string | null
         websiteUrl?: string | null
         starHistory?: Array<any | null> | null
+        owningPerson?: any | null
+        owningOrganization?: any | null
+        isTrendingDaily?: boolean | null
+        isTrendingWeekly?: boolean | null
+        isTrendingMonthly?: boolean | null
+        associatedPerson?: {
+          __typename?: 'AssociatedPerson'
+          id: any
+          login?: string | null
+          avatarUrl?: string | null
+        } | null
         organization?: {
           __typename?: 'Organization'
           id: any
-          nodeId: string
           login?: string | null
           avatarUrl?: string | null
         } | null
@@ -757,10 +777,9 @@ export const ProjectDetailsDocument = gql`
       edges {
         node {
           id
-          nodeId
-          eli5
-          about
           name
+          about
+          eli5
           starCount
           issueCount
           forkCount
@@ -769,9 +788,19 @@ export const ProjectDetailsDocument = gql`
           githubUrl
           websiteUrl
           starHistory
+          owningPerson
+          owningOrganization
+          associatedPerson {
+            id
+            name
+            login
+            avatarUrl
+            email
+            githubUrl
+            twitterUsername
+          }
           organization {
             id
-            nodeId
             login
             avatarUrl
           }
@@ -795,21 +824,30 @@ export const TrendingProjectsDocument = gql`
       edges {
         node {
           id
-          nodeId
           name
           starCount
           issueCount
           forkCount
           pullRequestCount
           contributorCount
+          githubUrl
           websiteUrl
           starHistory
-          organization {
+          owningPerson
+          owningOrganization
+          associatedPerson {
             id
-            nodeId
             login
             avatarUrl
           }
+          organization {
+            id
+            login
+            avatarUrl
+          }
+          isTrendingDaily
+          isTrendingWeekly
+          isTrendingMonthly
         }
       }
     }

--- a/src/graphql/queries/projectDetails.graphql
+++ b/src/graphql/queries/projectDetails.graphql
@@ -3,10 +3,9 @@ query ProjectDetails($id: UUID) {
     edges {
       node {
         id
-        nodeId
-        eli5
-        about
         name
+        about
+        eli5
         starCount
         issueCount
         forkCount
@@ -15,9 +14,19 @@ query ProjectDetails($id: UUID) {
         githubUrl
         websiteUrl
         starHistory
+        owningPerson
+        owningOrganization
+        associatedPerson {
+          id
+          name
+          login
+          avatarUrl
+          email
+          githubUrl
+          twitterUsername
+        }
         organization {
           id
-          nodeId
           login
           avatarUrl
         }

--- a/src/graphql/queries/trendingProjects.graphql
+++ b/src/graphql/queries/trendingProjects.graphql
@@ -3,21 +3,30 @@ query TrendingProjects {
     edges {
       node {
         id
-        nodeId
         name
         starCount
         issueCount
         forkCount
         pullRequestCount
         contributorCount
+        githubUrl
         websiteUrl
         starHistory
-        organization {
+        owningPerson
+        owningOrganization
+        associatedPerson {
           id
-          nodeId
           login
           avatarUrl
         }
+        organization {
+          id
+          login
+          avatarUrl
+        }
+        isTrendingDaily
+        isTrendingWeekly
+        isTrendingMonthly
       }
     }
   }


### PR DESCRIPTION
### Description of issue
Projects table and detail page now show actual logos, owners and eli5 description

### How I implemented
- Updated queries & ran codegen to regenerate types/ hooks
- Adapted table columns and detail page to use actual data
- Fixed outdated codegen config

### Other
<img width="338" alt="Screenshot 2023-06-11 at 07 58 19" src="https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/37487191/4553206d-37c2-4336-9de8-986b05de7b20">

<img width="1064" alt="Screenshot 2023-06-11 at 07 58 42" src="https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/37487191/4f96e2cb-86e4-414c-a702-ed75b13da5e2">
