### PR TITLE
[FRONT-100] Handle long project names

### DIFF
--- a/src/components/pure/ProjectsTable/columns.tsx
+++ b/src/components/pure/ProjectsTable/columns.tsx
@@ -25,14 +25,21 @@ const columns = [
   // @TODO Adjust for user owners
   columnHelper.accessor(
     ({ organization, associatedPerson, name }) =>
-      `${(organization?.login || associatedPerson?.login) as string} / ${name as string}`.slice(
-        0,
-        32
-      ),
+      `${(organization?.login || associatedPerson?.login) as string} / ${name as string}`,
     {
       id: 'nameWithOwner',
       header: 'Name',
-      cell: (info) => <p className="text-14 font-bold">{info.getValue()}</p>
+      cell: (info) => {
+        const [owner, name] = info.getValue().split(' / ')
+        return (
+          <div>
+            <span className="text-14 text-gray-500">{owner.slice(0, 15)}&nbsp;</span>
+            {owner.length > 16 && <span className="text-14 text-gray-500">...</span>}
+            <span className="text-14 font-bold">{name.slice(0, 31)}</span>
+            {name.length > 32 && <span className="text-14">...</span>}
+          </div>
+        )
+      }
     }
   ),
   // @TODO Add tags column

--- a/src/components/pure/ProjectsTable/columns.tsx
+++ b/src/components/pure/ProjectsTable/columns.tsx
@@ -33,7 +33,7 @@ const columns = [
         const [owner, name] = info.getValue().split(' / ')
         return (
           <div>
-            <span className="text-14 text-gray-500">{owner.slice(0, 15)}&nbsp;</span>
+            <span className="text-14 font-medium text-gray-500">{owner.slice(0, 15)} /&nbsp;</span>
             {owner.length > 16 && <span className="text-14 text-gray-500">...</span>}
             <span className="text-14 font-bold">{name.slice(0, 31)}</span>
             {name.length > 32 && <span className="text-14">...</span>}


### PR DESCRIPTION
## Description of Issue
[Linear issue](https://linear.app/la-famiglia-project/issue/FRONT-100/find-way-to-cut-long-long-project-names)

## How I implemented
I changed the UI a bit to differentiate between the owner and repo name. The current approach with the `/` doesn't look too good imo.
## Other
Here you can see an example of a project name being cut off:
![image](https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/61106168/4792898c-b541-45e9-9dee-7b428aa99267)
