### PR TITLE
[FRONT-136] Add PR Count to Overview page as column

### DIFF
--- a/src/components/pure/ProjectsTable/columns.tsx
+++ b/src/components/pure/ProjectsTable/columns.tsx
@@ -2,6 +2,7 @@ import { createColumnHelper } from '@tanstack/react-table'
 import { AiOutlineFork, AiOutlineStar } from 'react-icons/ai'
 import { BsPeople } from 'react-icons/bs'
 import { VscIssues } from 'react-icons/vsc'
+import { GoGitPullRequest } from 'react-icons/go'
 import GitHubStatisticItem from '@/components/pure/Sidebar/Box/GithubStatItem'
 import { Project } from '@/graphql/generated/gql'
 import formatNumber from '@/util/formatNumber'
@@ -121,6 +122,21 @@ const columns = [
     header: 'Issues/Contrib.',
     enableColumnFilter: true,
     cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
+  }),
+  // PR column definition
+  columnHelper.accessor('pullRequestCount', {
+    id: 'PR',
+    header: 'PR',
+    enableColumnFilter: true,
+    cell: (info) => (
+      <GitHubStatisticItem
+        Icon={GoGitPullRequest}
+        paddingOn={false}
+        outerPaddingOn={false}
+        hoverOn={false}
+        value={info.getValue() as number}
+      />
+    )
   })
 ]
 

--- a/src/components/pure/Sidebar/index.tsx
+++ b/src/components/pure/Sidebar/index.tsx
@@ -19,7 +19,7 @@ type SidebarProps = PropsWithChildren<{
  * @returns {ReactNode} Returns a sidebar component with provided footer and title, and children elements.
  */
 const Sidebar = ({ footer, ...props }: SidebarProps) => (
-  <aside className="fixed z-20 flex h-screen w-56 flex-initial flex-col justify-between border-r border-gray-800">
+  <aside className="fixed z-20 flex h-screen w-56 flex-initial flex-col justify-between border-r border-gray-800 bg-gray-900">
     <div>
       {/* Top bar with title and profile modal button */}
       <div className="flex h-[59px] w-full items-center justify-between px-7 text-gray-100">


### PR DESCRIPTION
### Description
Added PR count to the repository table page as a column.

### How I implemented
Just added one additional column
<img width="115" alt="Bildschirm­foto 2023-06-19 um 09 14 22" src="https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/94179814/ed774185-037c-4003-b0f5-cc4e2447066a">


### Other
Added bg color to Navbar so that when content overflow it's hidden behind that.
