### PR TITLE
[FRONT-141] Compare Page UI fixes

### DIFF
--- a/src/components/page/details/Chart.tsx
+++ b/src/components/page/details/Chart.tsx
@@ -178,9 +178,9 @@ const Chart = ({ datasets, multipleLines }: ChartProps) => {
 
           <ResponsiveContainer width="100%" height={300}>
             <LineChart
-              height={300}
+              height={310}
               margin={{
-                top: 25,
+                top: 30,
                 right: 10,
                 left: 0,
                 bottom: 5

--- a/src/components/side-effects/Compare/index.tsx
+++ b/src/components/side-effects/Compare/index.tsx
@@ -125,17 +125,36 @@ const Compare = () => {
           <h1 className="text-24 font-medium">Infrastructure</h1>
         </div>
 
-        <div>
+        <div className="flex flex-row items-center justify-end gap-2">
+          <Button
+            onClick={sendSlackMessage}
+            variant="normal"
+            text={slackLoading ? 'Loading...' : 'Send to Slack'}
+            Icon={FaSlack}
+            order="ltr"
+            textColor="white"
+          />
+
+          {notificationStatus === 'success' && (
+            <Banner variant="success" message="Slack notification sent" />
+          )}
+
+          {notificationStatus === 'error' && (
+            <Banner variant="error" message="Error sending notification" />
+          )}
           <Button
             variant="normal"
-            text="Stars"
-            Icon={FiChevronDown}
+            text="Add project to compare"
+            Icon={AiOutlinePlus}
             order="ltr"
             textColor="white"
           />
         </div>
       </div>
 
+      <div>
+        <Button variant="normal" text="Stars" Icon={FiChevronDown} order="ltr" textColor="white" />
+      </div>
       {!fetching && !error && data.length > 0 && (
         <>
           <Chart
@@ -150,32 +169,6 @@ const Compare = () => {
           <div className="flex flex-row items-center justify-between px-6 py-3.5">
             <div className="flex flex-col">
               <p className="font-medium">All projects in this category</p>
-            </div>
-
-            <div className="flex flex-row items-center justify-end gap-2">
-              <Button
-                onClick={sendSlackMessage}
-                variant="normal"
-                text={slackLoading ? 'Loading...' : 'Send to Slack'}
-                Icon={FaSlack}
-                order="ltr"
-                textColor="white"
-              />
-
-              {notificationStatus === 'success' && (
-                <Banner variant="success" message="Slack notification sent" />
-              )}
-
-              {notificationStatus === 'error' && (
-                <Banner variant="error" message="Error sending notification" />
-              )}
-              <Button
-                variant="normal"
-                text="Add project to compare"
-                Icon={AiOutlinePlus}
-                order="ltr"
-                textColor="white"
-              />
             </div>
           </div>
         </>

--- a/src/components/side-effects/Compare/index.tsx
+++ b/src/components/side-effects/Compare/index.tsx
@@ -5,7 +5,6 @@ import {
   ColumnOrderState,
   getFilteredRowModel
 } from '@tanstack/react-table'
-import { FiChevronDown } from 'react-icons/fi'
 import { AiOutlinePlus } from 'react-icons/ai'
 import { FaSlack } from 'react-icons/fa'
 import Error from '@/components/pure/Error'
@@ -152,9 +151,6 @@ const Compare = () => {
         </div>
       </div>
 
-      <div>
-        <Button variant="normal" text="Stars" Icon={FiChevronDown} order="ltr" textColor="white" />
-      </div>
       {!fetching && !error && data.length > 0 && (
         <>
           <Chart


### PR DESCRIPTION
### Description
[Linear Issue](https://linear.app/la-famiglia-project/issue/FRONT-141/compare-page-ui-fixes)

### How I implemented

<img width="1018" alt="Bildschirm­foto 2023-06-20 um 14 08 24" src="https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/94179814/82c1d722-9048-46f3-8151-125da2b0c323">


### Other
