### PR TITLE
[FRONT-128] Smart Green/Red Values in Table

### DIFF
--- a/src/components/page/login/LoginForm.tsx
+++ b/src/components/page/login/LoginForm.tsx
@@ -28,7 +28,7 @@ const LoginForm: FC<LoginFormProps> = ({ loading, error, handleSubmit }) => (
       className="w-full max-w-full py-3"
     />
     {error && (
-      <div className="mt-4 text-center text-sm text-red">
+      <div className="mt-4 text-center text-sm text-red-500">
         Invalid email or password. Please note that only invited users or La Famiglia employees can
         sign in.
       </div>

--- a/src/components/page/settings/Banner.tsx
+++ b/src/components/page/settings/Banner.tsx
@@ -9,8 +9,8 @@ const Banner = ({ message, variant }: BannerProps) => {
   const [isVisible, setIsVisible] = useState(true)
 
   const variantClasses = {
-    error: 'border-red bg-red/50 ',
-    success: 'border-green bg-green/90'
+    error: 'border-red-500 bg-red-500/50 ',
+    success: 'border-green-500 bg-green-500/90'
   }
 
   // Hide banner after 5 seconds (5000 ms)

--- a/src/components/pure/Button.tsx
+++ b/src/components/pure/Button.tsx
@@ -33,7 +33,7 @@ const variantToButtonVariantClassNames = new Map<ButtonProps['variant'], string>
   ['onlyIcon', 'bg-gray-850 border border-gray-800 px-1.5 py-1.5'],
   ['onlyIconNoBorderNoBG', ''],
   ['filter', 'border border-dashed border-gray-800 px-2 py-1.5'],
-  ['red', 'bg-red px-2 py-1.5']
+  ['red', 'bg-red-500 px-2 py-1.5']
 ])
 
 /**

--- a/src/components/pure/Sidebar/Box/GithubStatItem.tsx
+++ b/src/components/pure/Sidebar/Box/GithubStatItem.tsx
@@ -33,8 +33,6 @@ const GithubStatItem = ({
   largeGap
 }: GithubStatItemProps) => {
   let color = Color.DEFAULT
-  console.log(greenValue)
-  console.log(redValue)
   if (greenValue !== undefined && value >= greenValue) {
     color = Color.GREEN
   } else if (redValue !== undefined && value <= redValue) {

--- a/src/components/pure/Sidebar/Box/GithubStatItem.tsx
+++ b/src/components/pure/Sidebar/Box/GithubStatItem.tsx
@@ -6,6 +6,7 @@ enum Color {
   GREEN = 'text-green',
   RED = 'text-red'
 }
+
 type GithubStatItemProps = {
   Icon?: IconComponentType
   IconMetric?: ReactNode
@@ -32,9 +33,11 @@ const GithubStatItem = ({
   largeGap
 }: GithubStatItemProps) => {
   let color = Color.DEFAULT
-  if (greenValue !== undefined && value > greenValue) {
+  console.log(greenValue)
+  console.log(redValue)
+  if (greenValue !== undefined && value >= greenValue) {
     color = Color.GREEN
-  } else if (redValue !== undefined && value < redValue) {
+  } else if (redValue !== undefined && value <= redValue) {
     color = Color.RED
   }
 

--- a/src/components/pure/Sidebar/Box/GithubStatItem.tsx
+++ b/src/components/pure/Sidebar/Box/GithubStatItem.tsx
@@ -3,8 +3,10 @@ import formatNumber from '@/util/formatNumber'
 
 enum Color {
   DEFAULT = 'text-gray-100',
-  GREEN = 'text-green',
-  RED = 'text-red'
+  GREEN = 'text-green-500',
+  LIGHT_GREEN = 'text-green-300',
+  RED = 'text-red-500',
+  LIGHT_RED = 'text-red-300'
 }
 
 type GithubStatItemProps = {
@@ -15,7 +17,9 @@ type GithubStatItemProps = {
   paddingOn?: boolean
   outerPaddingOn?: boolean
   greenValue?: number
+  lightGreenValue?: number
   redValue?: number
+  lightRedValue?: number
   largeGap?: boolean
   link?: string
 }
@@ -28,15 +32,21 @@ const GithubStatItem = ({
   paddingOn,
   outerPaddingOn,
   greenValue,
+  lightGreenValue,
   redValue,
+  lightRedValue,
   largeGap,
   link
 }: GithubStatItemProps) => {
   let color = Color.DEFAULT
   if (greenValue !== undefined && value !== undefined && value > greenValue) {
     color = Color.GREEN
+  } else if (lightGreenValue !== undefined && value !== undefined && value > lightGreenValue) {
+    color = Color.LIGHT_GREEN
   } else if (redValue !== undefined && value !== undefined && value < redValue) {
     color = Color.RED
+  } else if (lightRedValue !== undefined && value !== undefined && value < lightRedValue) {
+    color = Color.LIGHT_RED
   }
 
   const gap = largeGap ? 'gap-[10px]' : 'gap-[5px]'
@@ -47,7 +57,7 @@ const GithubStatItem = ({
         <div className={`flex flex-row items-center justify-center text-xs ${gap}`}>
           {Icon && <Icon className={`h-[14px] w-[14px] ${color}`} />}
           {IconMetric}
-          {value && (
+          {value !== undefined && (
             <span className={`text-xs not-italic leading-3 ${paddingOn ? 'w-6' : ''} ${color}`}>
               {formatNumber(value)}
             </span>
@@ -72,7 +82,9 @@ GithubStatItem.defaultProps = {
   outerPaddingOn: true,
   paddingOn: true,
   greenValue: 100,
+  lightGreenValue: 75,
   redValue: 0,
+  lightRedValue: 25,
   largeGap: false,
   link: undefined
 }

--- a/src/components/side-effects/AddProject.tsx
+++ b/src/components/side-effects/AddProject.tsx
@@ -102,13 +102,13 @@ const AddProject = () => {
               />
 
               {success && (
-                <p className="text-sm text-green">
+                <p className="text-sm text-green-500">
                   Project added successfully! Please give us a few minutes to fetch all the data.
                 </p>
               )}
 
               {error && (
-                <p className="text-sm text-red">
+                <p className="text-sm text-red-500">
                   Failed to add project. Please make sure to provide a valid GitHub URL.
                 </p>
               )}

--- a/src/components/side-effects/ProjectsTable/columns.tsx
+++ b/src/components/side-effects/ProjectsTable/columns.tsx
@@ -10,7 +10,12 @@ import Image from 'next/image'
 
 type TenPercent = { [key in keyof Project]?: number | null }
 
-const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) => {
+const createColumns = (
+  topTenPercent: TenPercent,
+  bottomTenPercent: TenPercent,
+  topTwentyPercent: TenPercent,
+  bottomTwentyPercent: TenPercent
+) => {
   const columnHelper = createColumnHelper<Project>()
   return [
     // Logo column definition
@@ -62,7 +67,9 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           outerPaddingOn={false}
           value={info.getValue() as number}
           greenValue={bottomTenPercent.starCount as number}
+          lightGreenValue={topTwentyPercent.starCount as number}
           redValue={topTenPercent.starCount as number}
+          lightRedValue={bottomTwentyPercent.starCount as number}
         />
       )
     }),
@@ -78,7 +85,9 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           outerPaddingOn={false}
           value={info.getValue() as number}
           greenValue={bottomTenPercent.issueCount as number}
+          lightGreenValue={topTwentyPercent.issueCount as number}
           redValue={topTenPercent.issueCount as number}
+          lightRedValue={bottomTwentyPercent.issueCount as number}
         />
       )
     }),
@@ -94,7 +103,9 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           outerPaddingOn={false}
           value={info.getValue() as number}
           greenValue={bottomTenPercent.forkCount as number}
+          lightGreenValue={topTwentyPercent.forkCount as number}
           redValue={topTenPercent.forkCount as number}
+          lightRedValue={bottomTwentyPercent.forkCount as number}
         />
       )
     }),
@@ -108,9 +119,11 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           Icon={BsPeople}
           paddingOn={false}
           outerPaddingOn={false}
-          value={info.getValue() as number}
+          value={(info.getValue() as number) || 0}
           greenValue={bottomTenPercent.contributorCount as number}
+          lightGreenValue={topTwentyPercent.contributorCount as number}
           redValue={topTenPercent.contributorCount as number}
+          lightRedValue={bottomTwentyPercent.contributorCount as number}
         />
       )
     }),
@@ -141,9 +154,11 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           Icon={GoGitPullRequest}
           paddingOn={false}
           outerPaddingOn={false}
-          value={info.getValue() as number}
+          value={(info.getValue() as number) || 0}
           greenValue={bottomTenPercent.pullRequestCount as number}
+          lightGreenValue={topTwentyPercent.pullRequestCount as number}
           redValue={topTenPercent.pullRequestCount as number}
+          lightRedValue={bottomTwentyPercent.pullRequestCount as number}
         />
       )
     })

--- a/src/components/side-effects/ProjectsTable/columns.tsx
+++ b/src/components/side-effects/ProjectsTable/columns.tsx
@@ -62,42 +62,8 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           outerPaddingOn={false}
           hoverOn={false}
           value={info.getValue() as number}
-          greenValue={topTenPercent.starCount as number}
-          redValue={bottomTenPercent.starCount as number}
-        />
-      )
-    }),
-    // Issues column definition
-    columnHelper.accessor('issueCount', {
-      id: 'Issues',
-      header: 'Issues',
-      enableColumnFilter: true,
-      cell: (info) => (
-        <GitHubStatisticItem
-          Icon={VscIssues}
-          paddingOn={false}
-          outerPaddingOn={false}
-          hoverOn={false}
-          value={info.getValue() as number}
-          greenValue={topTenPercent.issueCount as number}
-          redValue={bottomTenPercent.issueCount as number}
-        />
-      )
-    }),
-    // Forks column definition
-    columnHelper.accessor('forkCount', {
-      id: 'Forks',
-      header: 'Forks',
-      enableColumnFilter: true,
-      cell: (info) => (
-        <GitHubStatisticItem
-          Icon={AiOutlineFork}
-          paddingOn={false}
-          outerPaddingOn={false}
-          hoverOn={false}
-          value={info.getValue() as number}
-          greenValue={topTenPercent.forkCount as number}
-          redValue={bottomTenPercent.forkCount as number}
+          greenValue={bottomTenPercent.starCount as number}
+          redValue={topTenPercent.starCount as number}
         />
       )
     }),
@@ -113,32 +79,15 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           outerPaddingOn={false}
           hoverOn={false}
           value={info.getValue() as number}
-          greenValue={topTenPercent.contributorCount as number}
-          redValue={bottomTenPercent.contributorCount as number}
+          greenValue={bottomTenPercent.contributorCount as number}
+          redValue={topTenPercent.contributorCount as number}
         />
       )
     }),
-    // Forks per Contributor column definition
-    columnHelper.accessor((project) => (project.forkCount || 0) / (project.contributorCount || 1), {
-      id: 'Forks/Contrib.',
-      header: 'Forks/Contrib.',
-      enableColumnFilter: true,
-      cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
-    }),
-    // Issues per Contributor column definition
-    columnHelper.accessor(
-      (project) => (project.issueCount || 0) / (project.contributorCount || 1),
-      {
-        id: 'Issues/Contrib.',
-        header: 'Issues/Contrib.',
-        enableColumnFilter: true,
-        cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
-      }
-    ),
     // PR column definition
     columnHelper.accessor('pullRequestCount', {
       id: 'PR',
-      header: 'PR',
+      header: 'PRs',
       enableColumnFilter: true,
       cell: (info) => (
         <GitHubStatisticItem
@@ -147,8 +96,61 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           outerPaddingOn={false}
           hoverOn={false}
           value={info.getValue() as number}
+          greenValue={bottomTenPercent.pullRequestCount as number}
+          redValue={topTenPercent.pullRequestCount as number}
         />
       )
+    }),
+    // Issues column definition
+    columnHelper.accessor('issueCount', {
+      id: 'Issues',
+      header: 'Issues',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={VscIssues}
+          paddingOn={false}
+          outerPaddingOn={false}
+          hoverOn={false}
+          value={info.getValue() as number}
+          greenValue={bottomTenPercent.issueCount as number}
+          redValue={topTenPercent.issueCount as number}
+        />
+      )
+    }),
+    // Issues per Contributor column definition
+    columnHelper.accessor(
+      (project) => (project.issueCount || 0) / (project.contributorCount || 1),
+      {
+        id: 'Issues/Contrib.',
+        header: 'I/Contrib.',
+        enableColumnFilter: true,
+        cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
+      }
+    ),
+    // Forks column definition
+    columnHelper.accessor('forkCount', {
+      id: 'Forks',
+      header: 'Forks',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={AiOutlineFork}
+          paddingOn={false}
+          outerPaddingOn={false}
+          hoverOn={false}
+          value={info.getValue() as number}
+          greenValue={bottomTenPercent.forkCount as number}
+          redValue={topTenPercent.forkCount as number}
+        />
+      )
+    }),
+    // Forks per Contributor column definition
+    columnHelper.accessor((project) => (project.forkCount || 0) / (project.contributorCount || 1), {
+      id: 'Forks/Contrib.',
+      header: 'F/Contrib.',
+      enableColumnFilter: true,
+      cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
     })
   ]
 }

--- a/src/components/side-effects/ProjectsTable/columns.tsx
+++ b/src/components/side-effects/ProjectsTable/columns.tsx
@@ -60,44 +60,9 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           Icon={AiOutlineStar}
           paddingOn={false}
           outerPaddingOn={false}
-          hoverOn={false}
           value={info.getValue() as number}
           greenValue={bottomTenPercent.starCount as number}
           redValue={topTenPercent.starCount as number}
-        />
-      )
-    }),
-    // Contributors column definition
-    columnHelper.accessor('contributorCount', {
-      id: 'Contrib.',
-      header: 'Contrib.',
-      enableColumnFilter: true,
-      cell: (info) => (
-        <GitHubStatisticItem
-          Icon={BsPeople}
-          paddingOn={false}
-          outerPaddingOn={false}
-          hoverOn={false}
-          value={info.getValue() as number}
-          greenValue={bottomTenPercent.contributorCount as number}
-          redValue={topTenPercent.contributorCount as number}
-        />
-      )
-    }),
-    // PR column definition
-    columnHelper.accessor('pullRequestCount', {
-      id: 'PR',
-      header: 'PRs',
-      enableColumnFilter: true,
-      cell: (info) => (
-        <GitHubStatisticItem
-          Icon={GoGitPullRequest}
-          paddingOn={false}
-          outerPaddingOn={false}
-          hoverOn={false}
-          value={info.getValue() as number}
-          greenValue={bottomTenPercent.pullRequestCount as number}
-          redValue={topTenPercent.pullRequestCount as number}
         />
       )
     }),
@@ -111,23 +76,12 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           Icon={VscIssues}
           paddingOn={false}
           outerPaddingOn={false}
-          hoverOn={false}
           value={info.getValue() as number}
           greenValue={bottomTenPercent.issueCount as number}
           redValue={topTenPercent.issueCount as number}
         />
       )
     }),
-    // Issues per Contributor column definition
-    columnHelper.accessor(
-      (project) => (project.issueCount || 0) / (project.contributorCount || 1),
-      {
-        id: 'Issues/Contrib.',
-        header: 'I/Contrib.',
-        enableColumnFilter: true,
-        cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
-      }
-    ),
     // Forks column definition
     columnHelper.accessor('forkCount', {
       id: 'Forks',
@@ -138,19 +92,60 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           Icon={AiOutlineFork}
           paddingOn={false}
           outerPaddingOn={false}
-          hoverOn={false}
           value={info.getValue() as number}
           greenValue={bottomTenPercent.forkCount as number}
           redValue={topTenPercent.forkCount as number}
         />
       )
     }),
+    // Contributors column definition
+    columnHelper.accessor('contributorCount', {
+      id: 'Contrib.',
+      header: 'Contrib.',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={BsPeople}
+          paddingOn={false}
+          outerPaddingOn={false}
+          value={info.getValue() as number}
+          greenValue={bottomTenPercent.contributorCount as number}
+          redValue={topTenPercent.contributorCount as number}
+        />
+      )
+    }),
     // Forks per Contributor column definition
     columnHelper.accessor((project) => (project.forkCount || 0) / (project.contributorCount || 1), {
       id: 'Forks/Contrib.',
-      header: 'F/Contrib.',
+      header: 'Forks/Contrib.',
       enableColumnFilter: true,
       cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
+    }),
+    // Issues per Contributor column definition
+    columnHelper.accessor(
+      (project) => (project.issueCount || 0) / (project.contributorCount || 1),
+      {
+        id: 'Issues/Contrib.',
+        header: 'Issues/Contrib.',
+        enableColumnFilter: true,
+        cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
+      }
+    ),
+    // PR column definition
+    columnHelper.accessor('pullRequestCount', {
+      id: 'PR',
+      header: 'Open PRs',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={GoGitPullRequest}
+          paddingOn={false}
+          outerPaddingOn={false}
+          value={info.getValue() as number}
+          greenValue={bottomTenPercent.pullRequestCount as number}
+          redValue={topTenPercent.pullRequestCount as number}
+        />
+      )
     })
   ]
 }

--- a/src/components/side-effects/ProjectsTable/columns.tsx
+++ b/src/components/side-effects/ProjectsTable/columns.tsx
@@ -8,132 +8,145 @@ import { Project } from '@/graphql/generated/gql'
 import formatNumber from '@/util/formatNumber'
 import Image from 'next/image'
 
-const columnHelper = createColumnHelper<Project>()
+type TenPercent = { [key in keyof Project]?: number | null }
 
-const columns = [
-  // Logo column definition
-  columnHelper.accessor(
-    ({ organization, associatedPerson }) => organization?.avatarUrl || associatedPerson?.avatarUrl,
-    {
-      header: 'Logo',
-      enableColumnFilter: false,
-      cell: (info) => (
-        <div className="relative ml-2 h-6 w-6 overflow-hidden rounded-[5px]">
-          <Image src={info.getValue() as string} alt="logo" fill sizes="24px" />
-        </div>
-      )
-    }
-  ),
-  // Name column definition
-  columnHelper.accessor(
-    ({ organization, associatedPerson, name }) =>
-      `${(organization?.login || associatedPerson?.login) as string} / ${name}`,
-    {
-      id: 'Name',
-      header: 'Name',
-      enableColumnFilter: true,
-      cell: (info) => {
-        const [owner, name] = info.getValue().split(' / ')
-        return (
-          <div>
-            <span className="text-14 font-medium text-gray-500">{owner.slice(0, 15)} /&nbsp;</span>
-            {owner.length > 16 && <span className="text-14 text-gray-500">...</span>}
-            <span className="text-14 font-bold">{name.slice(0, 31)}</span>
-            {name.length > 32 && <span className="text-14">...</span>}
+const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) => {
+  console.log(topTenPercent)
+  console.log(bottomTenPercent)
+  const columnHelper = createColumnHelper<Project>()
+  return [
+    // Logo column definition
+    columnHelper.accessor(
+      ({ organization, associatedPerson }) =>
+        organization?.avatarUrl || associatedPerson?.avatarUrl,
+      {
+        header: 'Logo',
+        enableColumnFilter: false,
+        cell: (info) => (
+          <div className="relative ml-2 h-6 w-6 overflow-hidden rounded-[5px]">
+            <Image src={info.getValue() as string} alt="logo" fill sizes="24px" />
           </div>
         )
       }
-    }
-  ),
-  // Stars column definition
-  columnHelper.accessor('starCount', {
-    id: 'Stars',
-    header: 'Stars',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={AiOutlineStar}
-        paddingOn={false}
-        outerPaddingOn={false}
-        hoverOn={false}
-        value={info.getValue() as number}
-      />
-    )
-  }),
-  // Issues column definition
-  columnHelper.accessor('issueCount', {
-    id: 'Issues',
-    header: 'Issues',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={VscIssues}
-        paddingOn={false}
-        outerPaddingOn={false}
-        hoverOn={false}
-        value={info.getValue() as number}
-      />
-    )
-  }),
-  // Forks column definition
-  columnHelper.accessor('forkCount', {
-    id: 'Forks',
-    header: 'Forks',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={AiOutlineFork}
-        paddingOn={false}
-        outerPaddingOn={false}
-        hoverOn={false}
-        value={info.getValue() as number}
-      />
-    )
-  }),
-  // Contributors column definition
-  columnHelper.accessor('contributorCount', {
-    id: 'Contrib.',
-    header: 'Contrib.',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={BsPeople}
-        paddingOn={false}
-        outerPaddingOn={false}
-        hoverOn={false}
-        value={info.getValue() as number}
-      />
-    )
-  }),
-  // Forks per Contributor column definition
-  columnHelper.accessor((project) => (project.forkCount || 0) / (project.contributorCount || 1), {
-    id: 'Forks/Contrib.',
-    header: 'Forks/Contrib.',
-    enableColumnFilter: true,
-    cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
-  }),
-  // Issues per Contributor column definition
-  columnHelper.accessor((project) => (project.issueCount || 0) / (project.contributorCount || 1), {
-    id: 'Issues/Contrib.',
-    header: 'Issues/Contrib.',
-    enableColumnFilter: true,
-    cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
-  }),
-  // PR column definition
-  columnHelper.accessor('pullRequestCount', {
-    id: 'PR',
-    header: 'PR',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={GoGitPullRequest}
-        paddingOn={false}
-        outerPaddingOn={false}
-        hoverOn={false}
-        value={info.getValue() as number}
-      />
-    )
-  })
-]
+    ),
+    // Name column definition
+    columnHelper.accessor(
+      ({ organization, associatedPerson, name }) =>
+        `${(organization?.login || associatedPerson?.login) as string} / ${name}`,
+      {
+        id: 'Name',
+        header: 'Name',
+        enableColumnFilter: true,
+        cell: (info) => {
+          const [owner, name] = info.getValue().split(' / ')
+          return (
+            <div>
+              <span className="text-14 font-medium text-gray-500">
+                {owner.slice(0, 15)} /&nbsp;
+              </span>
+              {owner.length > 16 && <span className="text-14 text-gray-500">...</span>}
+              <span className="text-14 font-bold">{name.slice(0, 31)}</span>
+              {name.length > 32 && <span className="text-14">...</span>}
+            </div>
+          )
+        }
+      }
+    ),
+    // Stars column definition
+    columnHelper.accessor('starCount', {
+      id: 'Stars',
+      header: 'Stars',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={AiOutlineStar}
+          paddingOn={false}
+          outerPaddingOn={false}
+          hoverOn={false}
+          value={info.getValue() as number}
+        />
+      )
+    }),
+    // Issues column definition
+    columnHelper.accessor('issueCount', {
+      id: 'Issues',
+      header: 'Issues',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={VscIssues}
+          paddingOn={false}
+          outerPaddingOn={false}
+          hoverOn={false}
+          value={info.getValue() as number}
+        />
+      )
+    }),
+    // Forks column definition
+    columnHelper.accessor('forkCount', {
+      id: 'Forks',
+      header: 'Forks',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={AiOutlineFork}
+          paddingOn={false}
+          outerPaddingOn={false}
+          hoverOn={false}
+          value={info.getValue() as number}
+          greenValue={topTenPercent.forkCount as number}
+          redValue={bottomTenPercent.forkCount as number}
+        />
+      )
+    }),
+    // Contributors column definition
+    columnHelper.accessor('contributorCount', {
+      id: 'Contrib.',
+      header: 'Contrib.',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={BsPeople}
+          paddingOn={false}
+          outerPaddingOn={false}
+          hoverOn={false}
+          value={info.getValue() as number}
+        />
+      )
+    }),
+    // Forks per Contributor column definition
+    columnHelper.accessor((project) => (project.forkCount || 0) / (project.contributorCount || 1), {
+      id: 'Forks/Contrib.',
+      header: 'Forks/Contrib.',
+      enableColumnFilter: true,
+      cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
+    }),
+    // Issues per Contributor column definition
+    columnHelper.accessor(
+      (project) => (project.issueCount || 0) / (project.contributorCount || 1),
+      {
+        id: 'Issues/Contrib.',
+        header: 'Issues/Contrib.',
+        enableColumnFilter: true,
+        cell: (info) => <p className="text-14">{formatNumber(info.getValue())}</p>
+      }
+    ),
+    // PR column definition
+    columnHelper.accessor('pullRequestCount', {
+      id: 'PR',
+      header: 'PR',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={GoGitPullRequest}
+          paddingOn={false}
+          outerPaddingOn={false}
+          hoverOn={false}
+          value={info.getValue() as number}
+        />
+      )
+    })
+  ]
+}
 
-export default columns
+export default createColumns

--- a/src/components/side-effects/ProjectsTable/columns.tsx
+++ b/src/components/side-effects/ProjectsTable/columns.tsx
@@ -11,8 +11,6 @@ import Image from 'next/image'
 type TenPercent = { [key in keyof Project]?: number | null }
 
 const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) => {
-  console.log(topTenPercent)
-  console.log(bottomTenPercent)
   const columnHelper = createColumnHelper<Project>()
   return [
     // Logo column definition
@@ -64,6 +62,8 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           outerPaddingOn={false}
           hoverOn={false}
           value={info.getValue() as number}
+          greenValue={topTenPercent.starCount as number}
+          redValue={bottomTenPercent.starCount as number}
         />
       )
     }),
@@ -79,6 +79,8 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           outerPaddingOn={false}
           hoverOn={false}
           value={info.getValue() as number}
+          greenValue={topTenPercent.issueCount as number}
+          redValue={bottomTenPercent.issueCount as number}
         />
       )
     }),
@@ -111,6 +113,8 @@ const createColumns = (topTenPercent: TenPercent, bottomTenPercent: TenPercent) 
           outerPaddingOn={false}
           hoverOn={false}
           value={info.getValue() as number}
+          greenValue={topTenPercent.contributorCount as number}
+          redValue={bottomTenPercent.contributorCount as number}
         />
       )
     }),

--- a/src/components/side-effects/ProjectsTable/index.tsx
+++ b/src/components/side-effects/ProjectsTable/index.tsx
@@ -88,7 +88,7 @@ const ProjectsTable = () => {
         .sort((a, b) => a - b)
 
       // Find the index that represents the bottom 10% (rounding down)
-      const bottomTenPercentIndex = Math.floor(sortedData.length / 10) - 1
+      const bottomTenPercentIndex = Math.ceil(sortedData.length / 10) - 1
       if (bottomTenPercentIndex >= 0 && sortedData.length > 0) {
         result[field] = sortedData[bottomTenPercentIndex]
       } else {

--- a/src/components/side-effects/ProjectsTable/index.tsx
+++ b/src/components/side-effects/ProjectsTable/index.tsx
@@ -34,11 +34,19 @@ const ProjectsTable = () => {
   }
 
   const [topTenPercent, setTopTenPercent] = useState<{ [key in keyof Project]?: number | null }>({})
+  const [topTwentyPercent, setTopTwentyPercent] = useState<{
+    [key in keyof Project]?: number | null
+  }>({})
   const [bottomTenPercent, setBottomTenPercent] = useState<{
     [key in keyof Project]?: number | null
   }>({})
+  const [bottomTwentyPercent, setBottomTwentyPercent] = useState<{
+    [key in keyof Project]?: number | null
+  }>({})
 
-  const [columns, setColumns] = useState(() => createColumns(bottomTenPercent, topTenPercent))
+  const [columns, setColumns] = useState(() =>
+    createColumns(bottomTenPercent, topTenPercent, topTwentyPercent, bottomTwentyPercent)
+  )
 
   const getTopTenPercent = (projects: Project[]) => {
     const numericFields: (keyof Project)[] = [
@@ -58,9 +66,38 @@ const ProjectsTable = () => {
         .filter((item): item is number => item !== undefined && item !== null)
         .sort((a, b) => b - a)
 
-      const topTenPercentIndex = Math.ceil(sortedData.length / 10) - 1
-      if (topTenPercentIndex >= 0 && sortedData.length > 0) {
+      const topTenPercentIndex = Math.floor(sortedData.length * 0.1)
+      if (topTenPercentIndex < sortedData.length && sortedData.length > 0) {
         result[field] = sortedData[topTenPercentIndex]
+      } else {
+        result[field] = null
+      }
+    })
+
+    return result
+  }
+
+  const getTopTwentyPercent = (projects: Project[]) => {
+    const numericFields: (keyof Project)[] = [
+      'contributorCount',
+      'forkCount',
+      'issueCount',
+      'pullRequestCount',
+      'starCount'
+    ]
+
+    const result: { [key in keyof Project]?: number | null } = {}
+
+    numericFields.forEach((field) => {
+      const sortedData = projects
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        .map((item) => item[field])
+        .filter((item): item is number => item !== undefined && item !== null)
+        .sort((a, b) => b - a)
+
+      const topTwentyPercentIndex = Math.floor(sortedData.length * 0.2)
+      if (topTwentyPercentIndex < sortedData.length && sortedData.length > 0) {
+        result[field] = sortedData[topTwentyPercentIndex]
       } else {
         result[field] = null
       }
@@ -87,9 +124,38 @@ const ProjectsTable = () => {
         .filter((item): item is number => item !== undefined && item !== null)
         .sort((a, b) => a - b)
 
-      const bottomTenPercentIndex = Math.ceil(sortedData.length / 10) - 1
-      if (bottomTenPercentIndex >= 0 && sortedData.length > 0) {
+      const bottomTenPercentIndex = Math.floor(sortedData.length * 0.1)
+      if (bottomTenPercentIndex < sortedData.length && sortedData.length > 0) {
         result[field] = sortedData[bottomTenPercentIndex]
+      } else {
+        result[field] = null
+      }
+    })
+
+    return result
+  }
+
+  const getBottomTwentyPercent = (projects: Project[]) => {
+    const numericFields: (keyof Project)[] = [
+      'contributorCount',
+      'forkCount',
+      'issueCount',
+      'pullRequestCount',
+      'starCount'
+    ]
+
+    const result: { [key in keyof Project]?: number | null } = {}
+
+    numericFields.forEach((field) => {
+      const sortedData = projects
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        .map((item) => item[field])
+        .filter((item): item is number => item !== undefined && item !== null)
+        .sort((a, b) => a - b)
+
+      const bottomTwentyPercentIndex = Math.floor(sortedData.length * 0.2)
+      if (bottomTwentyPercentIndex < sortedData.length && sortedData.length > 0) {
+        result[field] = sortedData[bottomTwentyPercentIndex]
       } else {
         result[field] = null
       }
@@ -109,21 +175,20 @@ const ProjectsTable = () => {
   // Only update table data when urql data changes
   useEffect(() => {
     if (urqlData) {
-      setData(urqlData?.projectCollection?.edges?.map((edge) => edge.node) as Project[])
-      setTopTenPercent(
-        getTopTenPercent(urqlData?.projectCollection?.edges?.map((edge) => edge.node) as Project[])
-      )
-      setBottomTenPercent(
-        getBottomTenPercent(
-          urqlData?.projectCollection?.edges?.map((edge) => edge.node) as Project[]
-        )
-      )
+      const projectData = urqlData?.projectCollection?.edges?.map((edge) => edge.node) as Project[]
+      setData(projectData)
+      setTopTenPercent(getTopTenPercent(projectData))
+      setBottomTenPercent(getBottomTenPercent(projectData))
+      setTopTwentyPercent(getTopTwentyPercent(projectData))
+      setBottomTwentyPercent(getBottomTwentyPercent(projectData))
     }
   }, [urqlData])
 
   useEffect(() => {
-    setColumns(() => createColumns(bottomTenPercent, topTenPercent))
-  }, [bottomTenPercent, topTenPercent])
+    setColumns(() =>
+      createColumns(bottomTenPercent, topTenPercent, topTwentyPercent, bottomTwentyPercent)
+    )
+  }, [bottomTenPercent, topTenPercent, topTwentyPercent, bottomTwentyPercent])
 
   // Initialize TanStack table
   const table = useReactTable({

--- a/src/components/side-effects/ProjectsTable/index.tsx
+++ b/src/components/side-effects/ProjectsTable/index.tsx
@@ -87,7 +87,6 @@ const ProjectsTable = () => {
         .filter((item): item is number => item !== undefined && item !== null)
         .sort((a, b) => a - b)
 
-      // Find the index that represents the bottom 10% (rounding down)
       const bottomTenPercentIndex = Math.ceil(sortedData.length / 10) - 1
       if (bottomTenPercentIndex >= 0 && sortedData.length > 0) {
         result[field] = sortedData[bottomTenPercentIndex]

--- a/src/components/side-effects/ProjectsTable/index.tsx
+++ b/src/components/side-effects/ProjectsTable/index.tsx
@@ -19,6 +19,40 @@ import {
 import { defaultFilters, defaultSort } from '@/components/page/overview/types'
 import createColumns from '@/components/side-effects/ProjectsTable/columns'
 
+// Constants
+const NUMERIC_FIELDS = [
+  'contributorCount',
+  'forkCount',
+  'issueCount',
+  'pullRequestCount',
+  'starCount'
+]
+
+// Utility Functions
+const getPercentileValue = (projects: Project[], percentile: number, sortDescending = true) => {
+  const result = {}
+  NUMERIC_FIELDS.forEach((field) => {
+    const sortedData = projects
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      .map((item) => item[field])
+      .filter((item) => !!item)
+      .sort((a, b) => (sortDescending ? b - a : a - b))
+
+    const percentileIndex = Math.floor(sortedData.length * percentile)
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    result[field] =
+      percentileIndex < sortedData.length && sortedData.length > 0
+        ? sortedData[percentileIndex]
+        : null
+  })
+
+  return result
+}
+
 /**
  * Table for displaying trending projects
  */
@@ -33,136 +67,18 @@ const ProjectsTable = () => {
     setFilters(filter)
   }
 
-  const [topTenPercent, setTopTenPercent] = useState<{ [key in keyof Project]?: number | null }>({})
-  const [topTwentyPercent, setTopTwentyPercent] = useState<{
-    [key in keyof Project]?: number | null
-  }>({})
-  const [bottomTenPercent, setBottomTenPercent] = useState<{
-    [key in keyof Project]?: number | null
-  }>({})
-  const [bottomTwentyPercent, setBottomTwentyPercent] = useState<{
-    [key in keyof Project]?: number | null
-  }>({})
+  const [percentileStats, setPercentileStats] = useState({
+    topTenPercent: {},
+    topTwentyPercent: {},
+    bottomTenPercent: {},
+    bottomTwentyPercent: {}
+  })
+
+  const { topTenPercent, topTwentyPercent, bottomTenPercent, bottomTwentyPercent } = percentileStats
 
   const [columns, setColumns] = useState(() =>
     createColumns(bottomTenPercent, topTenPercent, topTwentyPercent, bottomTwentyPercent)
   )
-
-  const getTopTenPercent = (projects: Project[]) => {
-    const numericFields: (keyof Project)[] = [
-      'contributorCount',
-      'forkCount',
-      'issueCount',
-      'pullRequestCount',
-      'starCount'
-    ]
-
-    const result: { [key in keyof Project]?: number | null } = {}
-
-    numericFields.forEach((field) => {
-      const sortedData = projects
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        .map((item) => item[field])
-        .filter((item): item is number => item !== undefined && item !== null)
-        .sort((a, b) => b - a)
-
-      const topTenPercentIndex = Math.floor(sortedData.length * 0.1)
-      if (topTenPercentIndex < sortedData.length && sortedData.length > 0) {
-        result[field] = sortedData[topTenPercentIndex]
-      } else {
-        result[field] = null
-      }
-    })
-
-    return result
-  }
-
-  const getTopTwentyPercent = (projects: Project[]) => {
-    const numericFields: (keyof Project)[] = [
-      'contributorCount',
-      'forkCount',
-      'issueCount',
-      'pullRequestCount',
-      'starCount'
-    ]
-
-    const result: { [key in keyof Project]?: number | null } = {}
-
-    numericFields.forEach((field) => {
-      const sortedData = projects
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        .map((item) => item[field])
-        .filter((item): item is number => item !== undefined && item !== null)
-        .sort((a, b) => b - a)
-
-      const topTwentyPercentIndex = Math.floor(sortedData.length * 0.2)
-      if (topTwentyPercentIndex < sortedData.length && sortedData.length > 0) {
-        result[field] = sortedData[topTwentyPercentIndex]
-      } else {
-        result[field] = null
-      }
-    })
-
-    return result
-  }
-
-  const getBottomTenPercent = (projects: Project[]) => {
-    const numericFields: (keyof Project)[] = [
-      'contributorCount',
-      'forkCount',
-      'issueCount',
-      'pullRequestCount',
-      'starCount'
-    ]
-
-    const result: { [key in keyof Project]?: number | null } = {}
-
-    numericFields.forEach((field) => {
-      const sortedData = projects
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        .map((item) => item[field])
-        .filter((item): item is number => item !== undefined && item !== null)
-        .sort((a, b) => a - b)
-
-      const bottomTenPercentIndex = Math.floor(sortedData.length * 0.1)
-      if (bottomTenPercentIndex < sortedData.length && sortedData.length > 0) {
-        result[field] = sortedData[bottomTenPercentIndex]
-      } else {
-        result[field] = null
-      }
-    })
-
-    return result
-  }
-
-  const getBottomTwentyPercent = (projects: Project[]) => {
-    const numericFields: (keyof Project)[] = [
-      'contributorCount',
-      'forkCount',
-      'issueCount',
-      'pullRequestCount',
-      'starCount'
-    ]
-
-    const result: { [key in keyof Project]?: number | null } = {}
-
-    numericFields.forEach((field) => {
-      const sortedData = projects
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        .map((item) => item[field])
-        .filter((item): item is number => item !== undefined && item !== null)
-        .sort((a, b) => a - b)
-
-      const bottomTwentyPercentIndex = Math.floor(sortedData.length * 0.2)
-      if (bottomTwentyPercentIndex < sortedData.length && sortedData.length > 0) {
-        result[field] = sortedData[bottomTwentyPercentIndex]
-      } else {
-        result[field] = null
-      }
-    })
-
-    return result
-  }
 
   // Fetch data from Supabase using generated Urql hook
   const [{ data: urqlData, fetching, error }] = useTrendingProjectsQuery({
@@ -172,17 +88,26 @@ const ProjectsTable = () => {
     }
   })
 
-  // Only update table data when urql data changes
+  // Effect Hooks
   useEffect(() => {
     if (urqlData) {
       const projectData = urqlData?.projectCollection?.edges?.map((edge) => edge.node) as Project[]
       setData(projectData)
-      setTopTenPercent(getTopTenPercent(projectData))
-      setBottomTenPercent(getBottomTenPercent(projectData))
-      setTopTwentyPercent(getTopTwentyPercent(projectData))
-      setBottomTwentyPercent(getBottomTwentyPercent(projectData))
+
+      setPercentileStats({
+        topTenPercent: getPercentileValue(projectData, 0.1),
+        bottomTenPercent: getPercentileValue(projectData, 0.1, false),
+        topTwentyPercent: getPercentileValue(projectData, 0.2),
+        bottomTwentyPercent: getPercentileValue(projectData, 0.2, false)
+      })
     }
   }, [urqlData])
+
+  useEffect(() => {
+    setColumns(() =>
+      createColumns(bottomTenPercent, topTenPercent, topTwentyPercent, bottomTwentyPercent)
+    )
+  }, [bottomTenPercent, topTenPercent, topTwentyPercent, bottomTwentyPercent])
 
   useEffect(() => {
     setColumns(() =>

--- a/src/components/side-effects/ProjectsTable/index.tsx
+++ b/src/components/side-effects/ProjectsTable/index.tsx
@@ -38,7 +38,7 @@ const ProjectsTable = () => {
     [key in keyof Project]?: number | null
   }>({})
 
-  const [columns] = useState(() => createColumns(bottomTenPercent, topTenPercent))
+  const [columns, setColumns] = useState(() => createColumns(bottomTenPercent, topTenPercent))
 
   const getTopTenPercent = (projects: Project[]) => {
     const numericFields: (keyof Project)[] = [
@@ -121,6 +121,10 @@ const ProjectsTable = () => {
       )
     }
   }, [urqlData])
+
+  useEffect(() => {
+    setColumns(() => createColumns(bottomTenPercent, topTenPercent))
+  }, [bottomTenPercent, topTenPercent])
 
   // Initialize TanStack table
   const table = useReactTable({

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -166,7 +166,7 @@ const Settings = () => {
             />
           ) : (
             <>
-              <p className="pb-6 text-14 font-normal text-red">Are you sure?</p>
+              <p className="pb-6 text-14 font-normal text-red-500">Are you sure?</p>
               <Link href="/logout">
                 <Button
                   onClick={handleDeleteAccount}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,7 +29,10 @@ module.exports = {
       },
       colors: {
         teal: '#01B3C0',
-        red: '#EC5858',
+        red: {
+          300: '#FFCCCB',
+          500: '#EC5858'
+        },
         mustard: '#988300',
         yellow: '#F3CA4D',
         orange: '#F3A04B',
@@ -38,7 +41,10 @@ module.exports = {
           500: '#8c8fd9'
         },
         blue: '#4FA8FD',
-        green: '#4DB783',
+        green: {
+          300: '#CFE1C9',
+          500: '#4DB783'
+        },
         indigo: {
           100: '#E1E8FF',
           300: '#A6B5FD',


### PR DESCRIPTION
## Description of Issue
The user wants an easy way to quickly find out if a value is good compared to the other value for that column/metric.
## How I implemented
Changed the columns const to a function that returns those columns, such that I could inject the top/bottom ten percent calculated in the Compare and Overview page.
## Other
The red/green indicators are always relative to the currently displayed rows. That means that if you filter by stars > 20.000, then even though gpt-engineer is 2nd in stars from all trending repos, its Star value won't be green, because it's only compared to the only other repo with > 20.000 stars, which has even more stars:
![image](https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/61106168/48eeafea-506c-41c4-afaf-c98931170b9d)

This is what the table looks like:
![image](https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/61106168/568e0870-817e-41ed-862b-e73e53fab23e)
Waiting for the calculated values to be merged to also have them be green/red
