### PR TITLE
[FRONT-90] Fix github metric icon z-index bug

### DIFF
--- a/src/components/page/details/Chart.tsx
+++ b/src/components/page/details/Chart.tsx
@@ -152,7 +152,7 @@ const Chart = ({ datasets, multipleLines, selectedMetric, setSelectedMetric }: C
               </Menu.Button>
 
               <MenuItemsTransition>
-                <Menu.Items className="z-30 mt-2 origin-top-right rounded-[5px] bg-gray-700 p-1 shadow-lg focus:outline-none">
+                <Menu.Items className="absolute left-0 z-30 mt-2 origin-top-left rounded-[5px] bg-gray-700 p-1 shadow-lg focus:outline-none">
                   {dataOptions.map((metric) => (
                     <Menu.Item
                       as="button"

--- a/src/components/page/details/GitHubMetricIcon.tsx
+++ b/src/components/page/details/GitHubMetricIcon.tsx
@@ -12,12 +12,12 @@ type GitHubMetricIconProps = {
  */
 const GitHubMetricIcon = ({ Icon, Icon2 }: GitHubMetricIconProps) => (
   <div className="relative h-4 w-4">
-    <Icon className="absolute left-0 top-0 z-10 h-2 w-2 text-white" />
+    <Icon className="absolute left-0 top-0 h-2 w-2 text-white" />
     <div
       className="absolute mb-[3px] ml-[3px] h-[1px] w-3 origin-bottom-left -rotate-45 rounded-full bg-white"
       style={{ bottom: '0', left: '0' }}
     />
-    <Icon2 className="absolute bottom-0 right-0 z-10 h-2 w-2 text-white" />
+    <Icon2 className="absolute bottom-0 right-0 h-2 w-2 text-white" />
   </div>
 )
 

--- a/src/components/side-effects/Details/BookmarkModal.tsx
+++ b/src/components/side-effects/Details/BookmarkModal.tsx
@@ -50,7 +50,7 @@ const BookmarkModal: FC<BookmarkModalProps> = ({
         const res = await addBookmarkMutation({ projectID, category: newCategory })
 
         // If the mutation was successful, show success message
-        if (res?.data?.addBookmark?.code === '204') {
+        if (res?.data?.addBookmark?.code === '201') {
           refetch()
         } else {
           // Otherwise, show error message


### PR DESCRIPTION
### Description of issue
important bug fix: icons have higher z-index than filterbar so they appear above it (see screenshot below)

<img width="813" alt="Screenshot 2023-06-23 at 13 57 16" src="https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/37487191/3e1007a8-0ff2-465f-8145-1aa47970cb5b">

### How I implemented
removed z-index from icons

### Other
come on philipp what else should I write in this bug fix description to pass your damn PR checks