### PR TITLE
[FRONT-128] Green/Red Value in Tables

### DIFF
--- a/src/components/page/details/GitHubMetricIcon.tsx
+++ b/src/components/page/details/GitHubMetricIcon.tsx
@@ -12,12 +12,12 @@ type GitHubMetricIconProps = {
  */
 const GitHubMetricIcon = ({ Icon, Icon2 }: GitHubMetricIconProps) => (
   <div className="relative h-4 w-4">
-    <Icon className="absolute left-0 top-0 h-2 w-2 text-white" />
+    <Icon className="absolute left-0 top-0 h-2 w-2 text-gray-300" />
     <div
-      className="absolute mb-[3px] ml-[3px] h-[1px] w-3 origin-bottom-left -rotate-45 rounded-full bg-white"
+      className="absolute mb-[3px] ml-[3px] h-[1px] w-3 origin-bottom-left -rotate-45 rounded-full bg-gray-300"
       style={{ bottom: '0', left: '0' }}
     />
-    <Icon2 className="absolute bottom-0 right-0 h-2 w-2 text-white" />
+    <Icon2 className="absolute bottom-0 right-0 h-2 w-2 text-gray-300" />
   </div>
 )
 

--- a/src/components/page/login/LoginForm.tsx
+++ b/src/components/page/login/LoginForm.tsx
@@ -28,7 +28,7 @@ const LoginForm: FC<LoginFormProps> = ({ loading, error, handleSubmit }) => (
       className="w-full max-w-full py-3"
     />
     {error && (
-      <div className="mt-4 text-center text-sm text-red">
+      <div className="mt-4 text-center text-sm text-red-500">
         Invalid email or password. Please note that only invited users or La Famiglia employees can
         sign in.
       </div>

--- a/src/components/pure/Sidebar/Box/GithubStatItem.tsx
+++ b/src/components/pure/Sidebar/Box/GithubStatItem.tsx
@@ -1,15 +1,15 @@
 import { ReactNode } from 'react'
 import formatNumber from '@/util/formatNumber'
-import Tooltip from '@/components/pure/Sidebar/Box/TooltipItem'
 
 enum Color {
   DEFAULT = 'text-gray-100',
-  GREEN = 'text-green',
-  RED = 'text-red'
+  GREEN = 'text-green-500',
+  LIGHT_GREEN = 'text-green-300',
+  RED = 'text-red-500',
+  LIGHT_RED = 'text-red-300'
 }
 
 type GithubStatItemProps = {
-  id?: string
   Icon?: IconComponentType
   IconMetric?: ReactNode
   value?: number
@@ -17,13 +17,14 @@ type GithubStatItemProps = {
   paddingOn?: boolean
   outerPaddingOn?: boolean
   greenValue?: number
+  lightGreenValue?: number
   redValue?: number
+  lightRedValue?: number
   largeGap?: boolean
   link?: string
 }
 
 const GithubStatItem = ({
-  id,
   Icon,
   value,
   growth,
@@ -31,15 +32,21 @@ const GithubStatItem = ({
   paddingOn,
   outerPaddingOn,
   greenValue,
+  lightGreenValue,
   redValue,
+  lightRedValue,
   largeGap,
   link
 }: GithubStatItemProps) => {
   let color = Color.DEFAULT
-  if (greenValue !== undefined && value !== undefined && value > greenValue) {
+  if (greenValue !== undefined && value !== undefined && value >= greenValue) {
     color = Color.GREEN
-  } else if (redValue !== undefined && value !== undefined && value < redValue) {
+  } else if (lightGreenValue !== undefined && value !== undefined && value >= lightGreenValue) {
+    color = Color.LIGHT_GREEN
+  } else if (redValue !== undefined && value !== undefined && value <= redValue) {
     color = Color.RED
+  } else if (lightRedValue !== undefined && value !== undefined && value <= lightRedValue) {
+    color = Color.LIGHT_RED
   }
 
   const gap = largeGap ? 'gap-[10px]' : 'gap-[5px]'
@@ -47,13 +54,10 @@ const GithubStatItem = ({
   return (
     <div className="flex flex-col justify-between">
       <div className={`inline-flex ${outerPaddingOn ? 'px-7' : ''} py-2.5`}>
-        <div
-          className={`flex flex-row items-center justify-center text-xs ${gap}`}
-          data-tooltip-id={id}
-        >
+        <div className={`flex flex-row items-center justify-center text-xs ${gap}`}>
           {Icon && <Icon className={`h-[14px] w-[14px] ${color}`} />}
           {IconMetric}
-          {value && (
+          {value !== undefined && (
             <span className={`text-xs not-italic leading-3 ${paddingOn ? 'w-6' : ''} ${color}`}>
               {formatNumber(value)}
             </span>
@@ -64,7 +68,6 @@ const GithubStatItem = ({
             </a>
           )}
           {growth && <span className="text-xs not-italic leading-3 text-gray-500">{growth}</span>}
-          <Tooltip id={id} />
         </div>
       </div>
     </div>
@@ -72,15 +75,16 @@ const GithubStatItem = ({
 }
 
 GithubStatItem.defaultProps = {
-  id: undefined,
   Icon: undefined,
   value: undefined,
   IconMetric: undefined,
   growth: undefined,
   outerPaddingOn: true,
   paddingOn: true,
-  greenValue: 100,
-  redValue: 0,
+  greenValue: undefined,
+  lightGreenValue: undefined,
+  redValue: undefined,
+  lightRedValue: undefined,
   largeGap: false,
   link: undefined
 }

--- a/src/components/pure/Sidebar/Box/GithubStatItem.tsx
+++ b/src/components/pure/Sidebar/Box/GithubStatItem.tsx
@@ -1,9 +1,9 @@
 import { ReactNode } from 'react'
 import formatNumber from '@/util/formatNumber'
-import { Tooltip } from 'react-tooltip'
+import Tooltip from './TooltipItem'
 
 enum Color {
-  DEFAULT = 'text-gray-100',
+  DEFAULT = 'text-gray-300',
   GREEN = 'text-green-500',
   LIGHT_GREEN = 'text-green-300',
   RED = 'text-red-500',
@@ -42,14 +42,14 @@ const GithubStatItem = ({
   link
 }: GithubStatItemProps) => {
   let color = Color.DEFAULT
-  if (greenValue !== undefined && value !== undefined && value >= greenValue) {
-    color = Color.GREEN
-  } else if (lightGreenValue !== undefined && value !== undefined && value >= lightGreenValue) {
+  if (greenValue && value && value >= greenValue) {
     color = Color.LIGHT_GREEN
-  } else if (redValue !== undefined && value !== undefined && value <= redValue) {
-    color = Color.RED
-  } else if (lightRedValue !== undefined && value !== undefined && value <= lightRedValue) {
+  } else if (lightGreenValue && value && value >= lightGreenValue) {
+    color = Color.GREEN
+  } else if (redValue && value && value <= redValue) {
     color = Color.LIGHT_RED
+  } else if (lightRedValue && value && value <= lightRedValue) {
+    color = Color.RED
   }
 
   const gap = largeGap ? 'gap-[10px]' : 'gap-[5px]'
@@ -63,8 +63,12 @@ const GithubStatItem = ({
         >
           {Icon && <Icon className={`h-[14px] w-[14px] ${color}`} />}
           {IconMetric}
-          {value !== undefined && (
-            <span className={`text-xs not-italic leading-3 ${paddingOn ? 'w-6' : ''} ${color}`}>
+          {value && (
+            <span
+              className={`text-xs font-medium not-italic leading-3 ${
+                paddingOn ? 'w-6' : ''
+              } ${color}`}
+            >
               {formatNumber(value)}
             </span>
           )}

--- a/src/components/pure/Sidebar/Box/GithubStatItem.tsx
+++ b/src/components/pure/Sidebar/Box/GithubStatItem.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from 'react'
 import formatNumber from '@/util/formatNumber'
+import { Tooltip } from 'react-tooltip'
 
 enum Color {
   DEFAULT = 'text-gray-100',
@@ -10,6 +11,7 @@ enum Color {
 }
 
 type GithubStatItemProps = {
+  id?: string
   Icon?: IconComponentType
   IconMetric?: ReactNode
   value?: number
@@ -25,6 +27,7 @@ type GithubStatItemProps = {
 }
 
 const GithubStatItem = ({
+  id,
   Icon,
   value,
   growth,
@@ -54,7 +57,10 @@ const GithubStatItem = ({
   return (
     <div className="flex flex-col justify-between">
       <div className={`inline-flex ${outerPaddingOn ? 'px-7' : ''} py-2.5`}>
-        <div className={`flex flex-row items-center justify-center text-xs ${gap}`}>
+        <div
+          className={`flex flex-row items-center justify-center text-xs ${gap}`}
+          data-tooltip-id={id}
+        >
           {Icon && <Icon className={`h-[14px] w-[14px] ${color}`} />}
           {IconMetric}
           {value !== undefined && (
@@ -68,6 +74,7 @@ const GithubStatItem = ({
             </a>
           )}
           {growth && <span className="text-xs not-italic leading-3 text-gray-500">{growth}</span>}
+          <Tooltip id={id} />
         </div>
       </div>
     </div>
@@ -75,6 +82,7 @@ const GithubStatItem = ({
 }
 
 GithubStatItem.defaultProps = {
+  id: undefined,
   Icon: undefined,
   value: undefined,
   IconMetric: undefined,

--- a/src/components/side-effects/AddProject.tsx
+++ b/src/components/side-effects/AddProject.tsx
@@ -117,14 +117,14 @@ const AddProject = () => {
 
                 {/* Success message */}
                 {success && (
-                  <p className="text-sm text-green">
+                  <p className="text-sm text-green-500">
                     Project added successfully! Please give us a few minutes to fetch all the data.
                   </p>
                 )}
 
                 {/* Error message */}
                 {error && (
-                  <p className="text-sm text-red">
+                  <p className="text-sm text-red-500">
                     Failed to add project. Please make sure to provide a valid GitHub URL.
                   </p>
                 )}

--- a/src/components/side-effects/CommandInterface/index.tsx
+++ b/src/components/side-effects/CommandInterface/index.tsx
@@ -11,7 +11,7 @@ import CommandInterfaceModal from './CommandInterfaceModal'
 import { RecommendationRowType } from './types'
 
 /**
- * Comand interface logic/ event listeners
+ * Command interface logic/ event listeners
  */
 const CommandInterface: React.FC = () => {
   const [open, setOpen] = useState<boolean>(false)

--- a/src/components/side-effects/Compare/CategoryModal.tsx
+++ b/src/components/side-effects/Compare/CategoryModal.tsx
@@ -89,7 +89,9 @@ const CategoryModal: FC<CategoryModalProps> = ({ open, toggleModal, category, re
 
               {/* Error message */}
               {error && (
-                <p className="text-sm text-red">Something went wrong. Please try again later.</p>
+                <p className="text-sm text-red-500">
+                  Something went wrong. Please try again later.
+                </p>
               )}
 
               <div className="flex w-full items-center justify-end">

--- a/src/components/side-effects/Compare/index.tsx
+++ b/src/components/side-effects/Compare/index.tsx
@@ -39,23 +39,27 @@ const NUMERIC_FIELDS = [
   'issueCount',
   'pullRequestCount',
   'starCount'
-]
+] as const
+
+type NumericField = (typeof NUMERIC_FIELDS)[number]
+type NumericFieldStats = Record<NumericField, number | null>
 
 const getPercentileValue = (projects: Project[], percentile: number, sortDescending = true) => {
-  const result = {}
+  const result: NumericFieldStats = {
+    contributorCount: null,
+    forkCount: null,
+    issueCount: null,
+    pullRequestCount: null,
+    starCount: null
+  }
+
   NUMERIC_FIELDS.forEach((field) => {
     const sortedData = projects
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-      .map((item) => item[field])
-      .filter((item) => !!item)
+      .map((item) => item[field] ?? null)
+      .filter((item: number | null): item is number => item !== null)
       .sort((a, b) => (sortDescending ? b - a : a - b))
 
     const percentileIndex = Math.floor(sortedData.length * percentile)
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     result[field] =
       percentileIndex < sortedData.length && sortedData.length > 0
         ? sortedData[percentileIndex]

--- a/src/components/side-effects/Compare/index.tsx
+++ b/src/components/side-effects/Compare/index.tsx
@@ -25,48 +25,13 @@ import {
   useTrendingProjectsQuery
 } from '@/graphql/generated/gql'
 import Banner from '@/components/page/settings/Banner'
-import sendSlackNotification from '@/util/sendSlackNotification'
+import CategoryModal from '@/components/side-effects/Compare/CategoryModal'
 import createColumns from '@/components/side-effects/ProjectsTable/columns'
-import CategoryModal from './CategoryModal'
+import getPercentile from '@/util/getPercentile'
+import sendSlackNotification from '@/util/sendSlackNotification'
 
 type CompareProps = {
   category: string
-}
-
-const NUMERIC_FIELDS = [
-  'contributorCount',
-  'forkCount',
-  'issueCount',
-  'pullRequestCount',
-  'starCount'
-] as const
-
-type NumericField = (typeof NUMERIC_FIELDS)[number]
-type NumericFieldStats = Record<NumericField, number | null>
-
-const getPercentileValue = (projects: Project[], percentile: number, sortDescending = true) => {
-  const result: NumericFieldStats = {
-    contributorCount: null,
-    forkCount: null,
-    issueCount: null,
-    pullRequestCount: null,
-    starCount: null
-  }
-
-  NUMERIC_FIELDS.forEach((field) => {
-    const sortedData = projects
-      .map((item) => item[field] ?? null)
-      .filter((item: number | null): item is number => item !== null)
-      .sort((a, b) => (sortDescending ? b - a : a - b))
-
-    const percentileIndex = Math.floor(sortedData.length * percentile)
-    result[field] =
-      percentileIndex < sortedData.length && sortedData.length > 0
-        ? sortedData[percentileIndex]
-        : null
-  })
-
-  return result
 }
 
 /**
@@ -140,10 +105,10 @@ const Compare = ({ category }: CompareProps) => {
       setData(projectData)
 
       setPercentileStats({
-        topTenPercent: getPercentileValue(projectData, 0.1),
-        bottomTenPercent: getPercentileValue(projectData, 0.1, false),
-        topTwentyPercent: getPercentileValue(projectData, 0.2),
-        bottomTwentyPercent: getPercentileValue(projectData, 0.2, false)
+        topTenPercent: getPercentile(projectData, 0.1),
+        bottomTenPercent: getPercentile(projectData, 0.1, false),
+        topTwentyPercent: getPercentile(projectData, 0.2),
+        bottomTwentyPercent: getPercentile(projectData, 0.2, false)
       })
     }
   }, [urqlData])

--- a/src/components/side-effects/Details/BookmarkModal.tsx
+++ b/src/components/side-effects/Details/BookmarkModal.tsx
@@ -139,7 +139,9 @@ const BookmarkModal: FC<BookmarkModalProps> = ({
 
               {/* Error message */}
               {error && (
-                <p className="text-sm text-red">Something went wrong. Please try again later.</p>
+                <p className="text-sm text-red-500">
+                  Something went wrong. Please try again later.
+                </p>
               )}
 
               <div
@@ -151,7 +153,7 @@ const BookmarkModal: FC<BookmarkModalProps> = ({
                 {isBookmarked && (
                   <Button
                     variant="noBorderNoBG"
-                    textColor="text-red"
+                    textColor="text-red-500"
                     text={fetchingDelete ? 'Deleting' : 'Delete'}
                     onClick={!fetchingDelete ? handleDelete : undefined}
                   />

--- a/src/components/side-effects/ProjectsTable/columns.tsx
+++ b/src/components/side-effects/ProjectsTable/columns.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import { createColumnHelper } from '@tanstack/react-table'
 import { AiOutlineFork, AiOutlineStar } from 'react-icons/ai'
 import { BsPeople } from 'react-icons/bs'
@@ -6,146 +5,179 @@ import { VscIssues } from 'react-icons/vsc'
 import { GoGitPullRequest } from 'react-icons/go'
 import GitHubStatisticItem from '@/components/pure/Sidebar/Box/GithubStatItem'
 import { Project } from '@/graphql/generated/gql'
+import Image from 'next/image'
+import { IssueOpenedIcon, PersonIcon, RepoForkedIcon } from '@primer/octicons-react'
 import GitHubMetricIcon from '@/components/page/details/GitHubMetricIcon'
-import { RepoForkedIcon, PersonIcon, IssueOpenedIcon } from '@primer/octicons-react'
 
-const columnHelper = createColumnHelper<Project>()
+type TenPercent = { [key in keyof Project]?: number | null }
 
-const columns = [
-  // Logo column definition
-  columnHelper.accessor(
-    ({ organization, associatedPerson }) => organization?.avatarUrl || associatedPerson?.avatarUrl,
-    {
-      header: 'Logo',
-      enableColumnFilter: false,
-      cell: (info) => (
-        <div className="relative ml-2 h-6 w-6 overflow-hidden rounded-[5px]">
-          <Image src={info.getValue() as string} alt="logo" fill sizes="24px" />
-        </div>
-      )
-    }
-  ),
-  // Name column definition
-  columnHelper.accessor(
-    ({ organization, associatedPerson, name }) =>
-      `${(organization?.login || associatedPerson?.login) as string} / ${name as string}`,
-    {
-      id: 'Name',
-      header: 'Name',
-      enableColumnFilter: true,
-      cell: (info) => {
-        const [owner, name] = info.getValue().split(' / ')
-        return (
-          <div>
-            <span className="text-14 font-medium text-gray-500">
-              {owner.slice(0, 15)}
-              {owner.length > 16 && '...'} /&nbsp;
-            </span>
-            <span className="text-14 font-bold">{name.slice(0, 31)}</span>
-            {name.length > 32 && <span className="text-14">...</span>}
+const createColumns = (
+  topTenPercent: TenPercent,
+  bottomTenPercent: TenPercent,
+  topTwentyPercent: TenPercent,
+  bottomTwentyPercent: TenPercent
+) => {
+  const columnHelper = createColumnHelper<Project>()
+  return [
+    // Logo column definition
+    columnHelper.accessor(
+      ({ organization, associatedPerson }) =>
+        organization?.avatarUrl || associatedPerson?.avatarUrl,
+      {
+        header: 'Logo',
+        enableColumnFilter: false,
+        cell: (info) => (
+          <div className="relative ml-2 h-6 w-6 overflow-hidden rounded-[5px]">
+            <Image src={info.getValue() as string} alt="logo" fill sizes="24px" />
           </div>
         )
       }
-    }
-  ),
-  // Stars column definition
-  columnHelper.accessor('starCount', {
-    id: 'Stars',
-    header: 'Stars',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={AiOutlineStar}
-        paddingOn={false}
-        outerPaddingOn={false}
-        value={info.getValue() as number}
-      />
-    )
-  }),
-  // Issues column definition
-  columnHelper.accessor('issueCount', {
-    id: 'Issues',
-    header: 'Issues',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={VscIssues}
-        paddingOn={false}
-        outerPaddingOn={false}
-        value={info.getValue() as number}
-      />
-    )
-  }),
-  // Forks column definition
-  columnHelper.accessor('forkCount', {
-    id: 'Forks',
-    header: 'Forks',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={AiOutlineFork}
-        paddingOn={false}
-        outerPaddingOn={false}
-        value={info.getValue() as number}
-      />
-    )
-  }),
-  // Contributors column definition
-  columnHelper.accessor('contributorCount', {
-    id: 'Contrib.',
-    header: 'Contrib.',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={BsPeople}
-        paddingOn={false}
-        outerPaddingOn={false}
-        value={(info.getValue() as number) || 0}
-      />
-    )
-  }),
-  // Forks per Contributor column definition
-  columnHelper.accessor((project) => (project.forkCount || 0) / (project.contributorCount || 1), {
-    id: 'Forks/Contrib.',
-    header: 'Forks/Contrib.',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        IconMetric={<GitHubMetricIcon Icon={RepoForkedIcon} Icon2={PersonIcon} />}
-        paddingOn={false}
-        outerPaddingOn={false}
-        value={info.getValue()}
-      />
-    )
-  }),
-  // Issues per Contributor column definition
-  columnHelper.accessor((project) => (project.issueCount || 0) / (project.contributorCount || 1), {
-    id: 'Issues/Contrib.',
-    header: 'Issues/Contrib.',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        IconMetric={<GitHubMetricIcon Icon={IssueOpenedIcon} Icon2={PersonIcon} />}
-        paddingOn={false}
-        outerPaddingOn={false}
-        value={info.getValue()}
-      />
-    )
-  }),
-  // PR column definition
-  columnHelper.accessor('pullRequestCount', {
-    id: 'PR',
-    header: 'Open PRs',
-    enableColumnFilter: true,
-    cell: (info) => (
-      <GitHubStatisticItem
-        Icon={GoGitPullRequest}
-        paddingOn={false}
-        outerPaddingOn={false}
-        value={info.getValue() as number}
-      />
-    )
-  })
-]
+    ),
+    // Name column definition
+    columnHelper.accessor(
+      ({ organization, associatedPerson, name }) =>
+        `${(organization?.login || associatedPerson?.login) as string} / ${name as string}`,
+      {
+        id: 'Name',
+        header: 'Name',
+        enableColumnFilter: true,
+        cell: (info) => {
+          const [owner, name] = info.getValue().split(' / ')
+          return (
+            <div>
+              <span className="text-14 font-medium text-gray-500">
+                {owner.slice(0, 15)} /&nbsp;
+              </span>
+              {owner.length > 16 && <span className="text-14 text-gray-500">...</span>}
+              <span className="text-14 font-bold">{name.slice(0, 31)}</span>
+              {name.length > 32 && <span className="text-14">...</span>}
+            </div>
+          )
+        }
+      }
+    ),
+    // Stars column definition
+    columnHelper.accessor('starCount', {
+      id: 'Stars',
+      header: 'Stars',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={AiOutlineStar}
+          paddingOn={false}
+          outerPaddingOn={false}
+          value={info.getValue() as number}
+          greenValue={bottomTenPercent.starCount as number}
+          lightGreenValue={topTwentyPercent.starCount as number}
+          redValue={topTenPercent.starCount as number}
+          lightRedValue={bottomTwentyPercent.starCount as number}
+        />
+      )
+    }),
+    // Issues column definition
+    columnHelper.accessor('issueCount', {
+      id: 'Issues',
+      header: 'Issues',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={VscIssues}
+          paddingOn={false}
+          outerPaddingOn={false}
+          value={info.getValue() as number}
+          greenValue={bottomTenPercent.issueCount as number}
+          lightGreenValue={topTwentyPercent.issueCount as number}
+          redValue={topTenPercent.issueCount as number}
+          lightRedValue={bottomTwentyPercent.issueCount as number}
+        />
+      )
+    }),
+    // Forks column definition
+    columnHelper.accessor('forkCount', {
+      id: 'Forks',
+      header: 'Forks',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={AiOutlineFork}
+          paddingOn={false}
+          outerPaddingOn={false}
+          value={info.getValue() as number}
+          greenValue={bottomTenPercent.forkCount as number}
+          lightGreenValue={topTwentyPercent.forkCount as number}
+          redValue={topTenPercent.forkCount as number}
+          lightRedValue={bottomTwentyPercent.forkCount as number}
+        />
+      )
+    }),
+    // Contributors column definition
+    columnHelper.accessor('contributorCount', {
+      id: 'Contrib.',
+      header: 'Contrib.',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={BsPeople}
+          paddingOn={false}
+          outerPaddingOn={false}
+          value={(info.getValue() as number) || 0}
+          greenValue={bottomTenPercent.contributorCount as number}
+          lightGreenValue={topTwentyPercent.contributorCount as number}
+          redValue={topTenPercent.contributorCount as number}
+          lightRedValue={bottomTwentyPercent.contributorCount as number}
+        />
+      )
+    }),
+    // Forks per Contributor column definition
+    columnHelper.accessor((project) => (project.forkCount || 0) / (project.contributorCount || 1), {
+      id: 'Forks/Contrib.',
+      header: 'Forks/Contrib.',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          IconMetric={<GitHubMetricIcon Icon={RepoForkedIcon} Icon2={PersonIcon} />}
+          paddingOn={false}
+          outerPaddingOn={false}
+          value={info.getValue()}
+        />
+      )
+    }),
+    // Issues per Contributor column definition
+    columnHelper.accessor(
+      (project) => (project.issueCount || 0) / (project.contributorCount || 1),
+      {
+        id: 'Issues/Contrib.',
+        header: 'Issues/Contrib.',
+        enableColumnFilter: true,
+        cell: (info) => (
+          <GitHubStatisticItem
+            IconMetric={<GitHubMetricIcon Icon={IssueOpenedIcon} Icon2={PersonIcon} />}
+            paddingOn={false}
+            outerPaddingOn={false}
+            value={info.getValue()}
+          />
+        )
+      }
+    ),
+    // PR column definition
+    columnHelper.accessor('pullRequestCount', {
+      id: 'PR',
+      header: 'Open PRs',
+      enableColumnFilter: true,
+      cell: (info) => (
+        <GitHubStatisticItem
+          Icon={GoGitPullRequest}
+          paddingOn={false}
+          outerPaddingOn={false}
+          value={(info.getValue() as number) || 0}
+          greenValue={bottomTenPercent.pullRequestCount as number}
+          lightGreenValue={topTwentyPercent.pullRequestCount as number}
+          redValue={topTenPercent.pullRequestCount as number}
+          lightRedValue={bottomTwentyPercent.pullRequestCount as number}
+        />
+      )
+    })
+  ]
+}
 
-export default columns
+export default createColumns

--- a/src/components/side-effects/ProjectsTable/index.tsx
+++ b/src/components/side-effects/ProjectsTable/index.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from 'react'
+import { FC, useMemo, useState } from 'react'
 import {
   useReactTable,
   getCoreRowModel,
@@ -9,10 +9,10 @@ import { CombinedError } from 'urql'
 import Error from '@/components/pure/Error'
 import Loading from '@/components/pure/Loading'
 import TopBar from '@/components/page/overview/TopBar'
-import defaultColumns from '@/components/side-effects/ProjectsTable/columns'
 import Table from '@/components/page/overview/Table'
 import FilterBar from '@/components/page/overview/FilterBar'
 import { Project, ProjectFilter, ProjectOrderBy } from '@/graphql/generated/gql'
+import createColumns from '@/components/side-effects/ProjectsTable/columns'
 
 type ProjectsTableProps = {
   data: Project[]
@@ -23,10 +23,17 @@ type ProjectsTableProps = {
   hideTimeFrame?: boolean
   setSorting: (sort: ProjectOrderBy | null) => void
   updateFilters: (filters: ProjectFilter) => void
+  percentileStats: {
+    topTenPercent: object
+    topTwentyPercent: object
+    bottomTenPercent: object
+    bottomTwentyPercent: object
+  }
 }
 
 /**
  * Table for displaying trending projects
+ *
  */
 const ProjectsTable: FC<ProjectsTableProps> = ({
   data,
@@ -36,11 +43,17 @@ const ProjectsTable: FC<ProjectsTableProps> = ({
   error,
   hideTimeFrame,
   setSorting,
-  updateFilters
+  updateFilters,
+  percentileStats
 }) => {
-  const [columns] = useState(() => [...defaultColumns])
   const [columnVisibility, setColumnVisibility] = useState({})
   const [columnOrder, setColumnOrder] = useState<ColumnOrderState>([])
+
+  const { topTenPercent, topTwentyPercent, bottomTenPercent, bottomTwentyPercent } = percentileStats
+  const columns = useMemo(
+    () => createColumns(bottomTenPercent, topTenPercent, topTwentyPercent, bottomTwentyPercent),
+    [bottomTenPercent, topTenPercent, topTwentyPercent, bottomTwentyPercent]
+  )
 
   // Initialize TanStack table
   const table = useReactTable({

--- a/src/pages/bookmarks.tsx
+++ b/src/pages/bookmarks.tsx
@@ -11,19 +11,9 @@ import {
   useBookmarkIdsQuery,
   useTrendingProjectsQuery
 } from '@/graphql/generated/gql'
+import getPercentile from '@/util/getPercentile'
 
 // @TODO add category column to table
-
-const NUMERIC_FIELDS = [
-  'contributorCount',
-  'forkCount',
-  'issueCount',
-  'pullRequestCount',
-  'starCount'
-] as const
-
-type NumericField = (typeof NUMERIC_FIELDS)[number]
-type NumericFieldStats = Record<NumericField, number | null>
 
 /**
  * Project table with all bookmarks of a user
@@ -32,31 +22,6 @@ const Bookmarks = () => {
   const [data, setData] = useState<Project[]>([])
   const [filters, setFilters] = useState<ProjectFilter>({})
   const [sorting, setSorting] = useState<ProjectOrderBy | null>(defaultSort)
-
-  const getPercentileValue = (projects: Project[], percentile: number, sortDescending = true) => {
-    const result: NumericFieldStats = {
-      contributorCount: null,
-      forkCount: null,
-      issueCount: null,
-      pullRequestCount: null,
-      starCount: null
-    }
-
-    NUMERIC_FIELDS.forEach((field) => {
-      const sortedData = projects
-        .map((item) => item[field] ?? null)
-        .filter((item: number | null): item is number => item !== null)
-        .sort((a, b) => (sortDescending ? b - a : a - b))
-
-      const percentileIndex = Math.floor(sortedData.length * percentile)
-      result[field] =
-        percentileIndex < sortedData.length && sortedData.length > 0
-          ? sortedData[percentileIndex]
-          : null
-    })
-
-    return result
-  }
 
   const user = useUser()
 
@@ -98,10 +63,10 @@ const Bookmarks = () => {
       const projectData = urqlData?.projectCollection?.edges?.map((edge) => edge.node) as Project[]
       setData(projectData)
       setPercentileStats({
-        topTenPercent: getPercentileValue(projectData, 0.1),
-        bottomTenPercent: getPercentileValue(projectData, 0.1, false),
-        topTwentyPercent: getPercentileValue(projectData, 0.2),
-        bottomTwentyPercent: getPercentileValue(projectData, 0.2, false)
+        topTenPercent: getPercentile(projectData, 0.1),
+        bottomTenPercent: getPercentile(projectData, 0.1, false),
+        topTwentyPercent: getPercentile(projectData, 0.2),
+        bottomTwentyPercent: getPercentile(projectData, 0.2, false)
       })
     }
   }, [urqlData])

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -17,7 +17,10 @@ const NUMERIC_FIELDS = [
   'issueCount',
   'pullRequestCount',
   'starCount'
-]
+] as const
+
+type NumericField = (typeof NUMERIC_FIELDS)[number]
+type NumericFieldStats = Record<NumericField, number | null>
 
 const TrendingProjects = () => {
   const [data, setData] = useState<Project[]>([])
@@ -25,20 +28,21 @@ const TrendingProjects = () => {
   const [sorting, setSorting] = useState<ProjectOrderBy | null>(defaultSort)
 
   const getPercentileValue = (projects: Project[], percentile: number, sortDescending = true) => {
-    const result = {}
+    const result: NumericFieldStats = {
+      contributorCount: null,
+      forkCount: null,
+      issueCount: null,
+      pullRequestCount: null,
+      starCount: null
+    }
+
     NUMERIC_FIELDS.forEach((field) => {
       const sortedData = projects
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-        .map((item) => item[field])
-        .filter((item) => !!item)
+        .map((item) => item[field] ?? null)
+        .filter((item: number | null): item is number => item !== null)
         .sort((a, b) => (sortDescending ? b - a : a - b))
 
       const percentileIndex = Math.floor(sortedData.length * percentile)
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       result[field] =
         percentileIndex < sortedData.length && sortedData.length > 0
           ? sortedData[percentileIndex]

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,47 +10,12 @@ import {
   useTrendingProjectsQuery
 } from '@/graphql/generated/gql'
 import defaultFilters from '@/components/page/overview/defaultFilters'
-
-const NUMERIC_FIELDS = [
-  'contributorCount',
-  'forkCount',
-  'issueCount',
-  'pullRequestCount',
-  'starCount'
-] as const
-
-type NumericField = (typeof NUMERIC_FIELDS)[number]
-type NumericFieldStats = Record<NumericField, number | null>
+import getPercentile from '@/util/getPercentile'
 
 const TrendingProjects = () => {
   const [data, setData] = useState<Project[]>([])
   const [filters, setFilters] = useState<ProjectFilter>(defaultFilters)
   const [sorting, setSorting] = useState<ProjectOrderBy | null>(defaultSort)
-
-  const getPercentileValue = (projects: Project[], percentile: number, sortDescending = true) => {
-    const result: NumericFieldStats = {
-      contributorCount: null,
-      forkCount: null,
-      issueCount: null,
-      pullRequestCount: null,
-      starCount: null
-    }
-
-    NUMERIC_FIELDS.forEach((field) => {
-      const sortedData = projects
-        .map((item) => item[field] ?? null)
-        .filter((item: number | null): item is number => item !== null)
-        .sort((a, b) => (sortDescending ? b - a : a - b))
-
-      const percentileIndex = Math.floor(sortedData.length * percentile)
-      result[field] =
-        percentileIndex < sortedData.length && sortedData.length > 0
-          ? sortedData[percentileIndex]
-          : null
-    })
-
-    return result
-  }
 
   const [percentileStats, setPercentileStats] = useState({
     topTenPercent: {},
@@ -77,10 +42,10 @@ const TrendingProjects = () => {
       const projectData = urqlData?.projectCollection?.edges?.map((edge) => edge.node) as Project[]
       setData(projectData)
       setPercentileStats({
-        topTenPercent: getPercentileValue(projectData, 0.1),
-        bottomTenPercent: getPercentileValue(projectData, 0.1, false),
-        topTwentyPercent: getPercentileValue(projectData, 0.2),
-        bottomTwentyPercent: getPercentileValue(projectData, 0.2, false)
+        topTenPercent: getPercentile(projectData, 0.1),
+        bottomTenPercent: getPercentile(projectData, 0.1, false),
+        topTwentyPercent: getPercentile(projectData, 0.2),
+        bottomTwentyPercent: getPercentile(projectData, 0.2, false)
       })
     }
   }, [urqlData])

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -11,10 +11,49 @@ import {
 } from '@/graphql/generated/gql'
 import defaultFilters from '@/components/page/overview/defaultFilters'
 
+const NUMERIC_FIELDS = [
+  'contributorCount',
+  'forkCount',
+  'issueCount',
+  'pullRequestCount',
+  'starCount'
+]
+
 const TrendingProjects = () => {
   const [data, setData] = useState<Project[]>([])
   const [filters, setFilters] = useState<ProjectFilter>(defaultFilters)
   const [sorting, setSorting] = useState<ProjectOrderBy | null>(defaultSort)
+
+  const getPercentileValue = (projects: Project[], percentile: number, sortDescending = true) => {
+    const result = {}
+    NUMERIC_FIELDS.forEach((field) => {
+      const sortedData = projects
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        .map((item) => item[field])
+        .filter((item) => !!item)
+        .sort((a, b) => (sortDescending ? b - a : a - b))
+
+      const percentileIndex = Math.floor(sortedData.length * percentile)
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      result[field] =
+        percentileIndex < sortedData.length && sortedData.length > 0
+          ? sortedData[percentileIndex]
+          : null
+    })
+
+    return result
+  }
+
+  const [percentileStats, setPercentileStats] = useState({
+    topTenPercent: {},
+    topTwentyPercent: {},
+    bottomTenPercent: {},
+    bottomTwentyPercent: {}
+  })
 
   const updateFilters = (filter: ProjectFilter) => {
     setFilters(filter)
@@ -31,7 +70,14 @@ const TrendingProjects = () => {
   // Only update table data when urql data changes
   useEffect(() => {
     if (urqlData) {
-      setData(urqlData?.projectCollection?.edges?.map((edge) => edge.node) as Project[])
+      const projectData = urqlData?.projectCollection?.edges?.map((edge) => edge.node) as Project[]
+      setData(projectData)
+      setPercentileStats({
+        topTenPercent: getPercentileValue(projectData, 0.1),
+        bottomTenPercent: getPercentileValue(projectData, 0.1, false),
+        topTwentyPercent: getPercentileValue(projectData, 0.2),
+        bottomTwentyPercent: getPercentileValue(projectData, 0.2, false)
+      })
     }
   }, [urqlData])
 
@@ -45,6 +91,7 @@ const TrendingProjects = () => {
         error={error}
         setSorting={setSorting}
         updateFilters={updateFilters}
+        percentileStats={percentileStats}
       />
     </Page>
   )

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -83,7 +83,7 @@ const Login = () => {
         />
 
         {error === 'invalid_email' && (
-          <div className="text-center text-sm text-red">
+          <div className="text-center text-sm text-red-500">
             Invalid google email or password. Please note that only invited users or La Famiglia
             employees can sign in.
           </div>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -166,7 +166,7 @@ const Settings = () => {
             />
           ) : (
             <>
-              <p className="pb-6 text-14 font-normal text-red">Are you sure?</p>
+              <p className="pb-6 text-14 font-normal text-red-500">Are you sure?</p>
               <Link href="/logout">
                 <Button
                   onClick={handleDeleteAccount}

--- a/src/util/getPercentile.ts
+++ b/src/util/getPercentile.ts
@@ -1,0 +1,40 @@
+import { Project } from '@/graphql/generated/gql'
+
+const NUMERIC_FIELDS = [
+  'contributorCount',
+  'forkCount',
+  'issueCount',
+  'pullRequestCount',
+  'starCount'
+] as const
+
+type NumericField = (typeof NUMERIC_FIELDS)[number]
+type NumericFieldStats = Record<NumericField, number | null>
+
+const getPercentile = (projects: Project[], percentile: number, sortDescending = true) => {
+  const result: NumericFieldStats = {
+    contributorCount: null,
+    forkCount: null,
+    issueCount: null,
+    pullRequestCount: null,
+    starCount: null
+  }
+
+  NUMERIC_FIELDS.forEach((field) => {
+    const sortedData = projects
+      .map((item) => item[field] ?? null)
+      .filter((item: number | null): item is number => item !== null)
+      .sort((a, b) => (sortDescending ? b - a : a - b))
+
+    const percentileIndex = Math.floor(sortedData.length * percentile)
+
+    result[field] =
+      percentileIndex < sortedData.length && sortedData.length > 0
+        ? sortedData[percentileIndex]
+        : null
+  })
+
+  return result
+}
+
+export default getPercentile

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,7 +29,10 @@ module.exports = {
       },
       colors: {
         teal: '#01B3C0',
-        red: '#EC5858',
+        red: {
+          300: '#FFCCCB',
+          500: '#EC5858'
+        },
         mustard: '#988300',
         yellow: '#F3CA4D',
         orange: '#F3A04B',
@@ -38,7 +41,10 @@ module.exports = {
           500: '#8c8fd9'
         },
         blue: '#4FA8FD',
-        green: '#4DB783',
+        green: {
+          300: '#CFE1C9',
+          500: '#4DB783'
+        },
         indigo: {
           100: '#E1E8FF',
           300: '#A6B5FD',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,8 +30,8 @@ module.exports = {
       colors: {
         teal: '#01B3C0',
         red: {
-          300: '#FFCCCB',
-          500: '#EC5858'
+          300: '#e57069',
+          500: '#c5534b'
         },
         mustard: '#988300',
         yellow: '#F3CA4D',
@@ -42,8 +42,8 @@ module.exports = {
         },
         blue: '#4FA8FD',
         green: {
-          300: '#CFE1C9',
-          500: '#4DB783'
+          300: '#3ad48d',
+          500: '#36956a'
         },
         indigo: {
           100: '#E1E8FF',


### PR DESCRIPTION
## Description of Issue
The user wants an easy way to quickly find out if a value is good compared to the other value for that column/metric.
## How I implemented
Changed the columns const to a function that returns those columns, such that I could inject the top/bottom ten percent calculated in the Compare and Overview page.
## Other
The red/green indicators are always relative to the currently displayed rows. That means that if you filter by stars > 20.000, then even though gpt-engineer is 2nd in stars from all trending repos, its Star value won't be green, because it's only compared to the only other repo with > 20.000 stars, which has even more stars:
![image](https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/61106168/48eeafea-506c-41c4-afaf-c98931170b9d)

This is what the table looks like:
![image](https://github.com/jst-seminar-rostlab-tum/truffle-ai-frontend/assets/61106168/568e0870-817e-41ed-862b-e73e53fab23e)
Waiting for the calculated values to be merged to also have them be green/red
